### PR TITLE
Add Makefile with build and run helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Makefile for Bifrost
+
+# setup: Install Go 1.23.8 and project dependencies
+setup:
+	go install golang.org/dl/go1.23.8@latest
+	go1.23.8 download
+	go mod download
+
+# build: Compile all Go packages using Go 1.23.8
+build:
+	go1.23.8 build ./...
+
+# run: Execute the main application using Go 1.23.8
+run:
+	go1.23.8 run main.go
+


### PR DESCRIPTION
## Summary
- add basic Makefile for setup, build and run

## Testing
- `make setup` *(fails: module download blocked)*
- `make build` *(fails: `go1.23.8` command missing)*
- `make run` *(fails: `go1.23.8` command missing)*
- `go mod download` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685629b8aa38832a9dbec40409e47ddb