### PR TITLE
Add healthz endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	m "github.com/FokusInternal/bifrost/middlewares"
+	routes "github.com/FokusInternal/bifrost/routes"
 	v1 "github.com/FokusInternal/bifrost/routes/v1"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -15,6 +16,8 @@ func main() {
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+
+	r.Get("/healthz", routes.Healthz)
 
 	r.Route("/v1", func(r chi.Router) {
 		r.Use(apiVersionCtx("v1"))

--- a/routes/health.go
+++ b/routes/health.go
@@ -1,0 +1,8 @@
+package routes
+
+import "net/http"
+
+// Healthz responds with a simple string to indicate the service is running.
+func Healthz(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("ok"))
+}


### PR DESCRIPTION
## Summary
- register `/healthz` route in `main.go`
- implement health check handler

## Testing
- `go vet ./...`
- `go build ./...`
- `go mod tidy` *(fails: access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68562cbdf360832a962ae8045fa85a0e