### PR TITLE
Introduce configurable ports and redis address

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"os"
+	"strconv"
+)
+
+// ServerPort returns the port the HTTP server should listen on.
+// It reads the BIFROST_PORT environment variable and defaults to "3333" if unset.
+// A leading colon is added if missing.
+func ServerPort() string {
+	port := os.Getenv("BIFROST_PORT")
+	if port == "" {
+		port = "3333"
+	}
+	if len(port) > 0 && port[0] != ':' {
+		return ":" + port
+	}
+	return port
+}
+
+// RedisAddr returns the address of the redis server.
+// It reads the REDIS_ADDR environment variable and defaults to "localhost:6379".
+func RedisAddr() string {
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		addr = "localhost:6379"
+	}
+	return addr
+}
+
+// RedisPassword returns the password for redis if set via REDIS_PASSWORD.
+func RedisPassword() string {
+	return os.Getenv("REDIS_PASSWORD")
+}
+
+// RedisDB returns the database index for redis, defaulting to 0.
+func RedisDB() int {
+	if v := os.Getenv("REDIS_DB"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
+// RedisProtocol returns the protocol version for redis connections, defaulting to 3.
+func RedisProtocol() int {
+	if v := os.Getenv("REDIS_PROTOCOL"); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return 3
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/FokusInternal/bifrost/config"
 	m "github.com/FokusInternal/bifrost/middlewares"
 	routes "github.com/FokusInternal/bifrost/routes"
 	v1 "github.com/FokusInternal/bifrost/routes/v1"
@@ -27,7 +28,7 @@ func main() {
 		r.With(m.RateLimitMiddleware()).Post("/rate", v1.SayHello)
 	})
 
-	http.ListenAndServe(":3333", r)
+	http.ListenAndServe(config.ServerPort(), r)
 }
 
 func apiVersionCtx(version string) func(next http.Handler) http.Handler {

--- a/middlewares/ratelimitting.go
+++ b/middlewares/ratelimitting.go
@@ -5,17 +5,16 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/FokusInternal/bifrost/config"
 	redis "github.com/redis/go-redis/v9"
 )
 
-// TODO: This connection string should come from an env var. Replace all hardcoded values.
-
-// Redis connector to manage rate limitting
+// Redis connector to manage rate limiting using configuration values.
 var rdb = redis.NewClient(&redis.Options{
-	Addr:     "localhost:6379",
-	Password: "",
-	DB:       0,
-	Protocol: 3,
+	Addr:     config.RedisAddr(),
+	Password: config.RedisPassword(),
+	DB:       config.RedisDB(),
+	Protocol: config.RedisProtocol(),
 })
 
 func RateLimitMiddleware() func(http.Handler) http.Handler {


### PR DESCRIPTION
## Summary
- add `config` package for environment-based settings
- use `config.ServerPort()` in `main.go`
- construct Redis client from config values

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_68562f1ec900832a8ee63a63d4907642