### PR TITLE
Document env vars and example run

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,24 @@ make run
 
 If you want to exercise the rate‑limit middleware, ensure Redis is running (for example via `docker run -d --name redis-dev -p 6379:6379 redis:7-alpine`).
 
+### Configuration via Environment Variables
+
+Bifrost can be configured through a handful of environment variables:
+
+- `BIFROST_PORT` – HTTP port to bind to (defaults to `3333`).
+- `REDIS_ADDR` – address of the Redis instance (defaults to `localhost:6379`).
+- `REDIS_PASSWORD` – password for Redis, if required.
+- `REDIS_DB` – numeric Redis DB index to use (defaults to `0`).
+- `REDIS_PROTOCOL` – Redis protocol version (defaults to `3`).
+
+You can export these variables or prefix them when starting the server.
+
+#### Example
+
+```bash
+BIFROST_PORT=8080 REDIS_ADDR=localhost:6379 make run
+```
+
 
 # Core Features
 ## Virtual Key Mapping


### PR DESCRIPTION
## Summary
- document environment variables in README
- show how to run server with custom settings

## Testing
- `go1.23.8 test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685633e3b3cc832a804912cf2de1a827