### PR TITLE
Add CLI for issuing and revoking keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ Log, trace, and monitor access by key, user, origin, or service.
 ## Golang First
 Fast, type-safe, and built for performance and extensibility.
 
+## CLI Usage
+You can manage virtual keys from the command line with the `bifrost` tool.
+The commands interact with the running HTTP API by default.
+
+```bash
+# issue a new key
+go run ./cmd/bifrost issue --id mykey --target svc --scope read --ttl 10m
+
+# revoke an existing key
+go run ./cmd/bifrost revoke mykey
+```
+
+Use `--addr` to specify a custom API address if the server is not running on
+`http://localhost:3333`.
+
 
 # Planned Extensions
 - Integration with Open Policy Agent (OPA) for dynamic authorization.

--- a/cmd/bifrost/issue.go
+++ b/cmd/bifrost/issue.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/FokusInternal/bifrost/pkg/keys"
+	"github.com/spf13/cobra"
+)
+
+var (
+	issueID     string
+	issueScope  string
+	issueTarget string
+	issueTTL    time.Duration
+)
+
+var issueCmd = &cobra.Command{
+	Use:   "issue",
+	Short: "Issue a virtual key",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		k := keys.VirtualKey{
+			ID:        issueID,
+			Scope:     issueScope,
+			Target:    issueTarget,
+			ExpiresAt: time.Now().Add(issueTTL),
+		}
+		body, err := json.Marshal(k)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Post(serverAddr+"/v1/keys", "application/json", bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		io.Copy(os.Stdout, resp.Body)
+		return nil
+	},
+}
+
+func init() {
+	issueCmd.Flags().StringVar(&issueID, "id", "", "ID of the key")
+	issueCmd.Flags().StringVar(&issueScope, "scope", "", "scope for the key")
+	issueCmd.Flags().StringVar(&issueTarget, "target", "", "target service")
+	issueCmd.Flags().DurationVar(&issueTTL, "ttl", time.Hour, "time to live")
+	issueCmd.MarkFlagRequired("id")
+	issueCmd.MarkFlagRequired("target")
+	rootCmd.AddCommand(issueCmd)
+}

--- a/cmd/bifrost/main.go
+++ b/cmd/bifrost/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	Execute()
+}

--- a/cmd/bifrost/revoke.go
+++ b/cmd/bifrost/revoke.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke [id]",
+	Short: "Revoke a virtual key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		req, err := http.NewRequest(http.MethodDelete, serverAddr+"/v1/keys/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		fmt.Println("revoked")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(revokeCmd)
+}

--- a/cmd/bifrost/root.go
+++ b/cmd/bifrost/root.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "bifrost",
+	Short: "Bifrost command line interface",
+}
+
+var serverAddr string
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&serverAddr, "addr", "http://localhost:3333", "bifrost API address")
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,14 @@ module github.com/FokusInternal/bifrost
 go 1.23.8
 
 require (
+	github.com/go-chi/chi/v5 v5.2.1
+	github.com/redis/go-redis/v9 v9.9.0
+	github.com/spf13/cobra v1.9.1
+)
+
+require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/go-chi/chi/v5 v5.2.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/redis/go-redis/v9 v9.9.0 // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 )


### PR DESCRIPTION
## Summary
- add cobra-based CLI in `cmd/bifrost`
- support `issue` and `revoke` commands that call the HTTP API
- document CLI usage
- tidy `go.mod`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68563aaf330c832ab763aa6148d7292a