### PR TITLE
Add service proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ go run ./cmd/bifrost issue --id mykey --target svc --scope read --ttl 10m
 
 # revoke an existing key
 go run ./cmd/bifrost revoke mykey
+
+# register a service
+go run ./cmd/bifrost service-add --id svc --endpoint http://localhost:8081 --apikey SECRET
+
+# delete a service
+go run ./cmd/bifrost service-delete svc
 ```
 
 Use `--addr` to specify a custom API address if the server is not running on
@@ -104,6 +110,25 @@ returns status `204 No Content`.
 ```bash
 curl -X DELETE http://localhost:3333/v1/keys/mykey
 ```
+
+### Add a service
+POST `/v1/services` with JSON describing the service. Returns `201 Created`.
+
+Example:
+
+```bash
+curl -X POST http://localhost:3333/v1/services \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"svc","endpoint":"http://localhost:8081","api_key":"SECRET"}'
+```
+
+### Delete a service
+DELETE `/v1/services/<id>` to remove a service.
+
+### Proxy using a virtual key
+Send any request to `/v1/proxy/<path>` with header `X-Virtual-Key` set to a
+previously issued key. Bifrost injects the real API key and forwards the request
+to the mapped service.
 
 
 # Planned Extensions

--- a/cmd/bifrost/service_add.go
+++ b/cmd/bifrost/service_add.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/FokusInternal/bifrost/pkg/services"
+	"github.com/spf13/cobra"
+)
+
+var (
+	serviceAddID       string
+	serviceAddEndpoint string
+	serviceAddAPIKey   string
+)
+
+var serviceAddCmd = &cobra.Command{
+	Use:   "service-add",
+	Short: "Add a service",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		svc := services.Service{ID: serviceAddID, Endpoint: serviceAddEndpoint, APIKey: serviceAddAPIKey}
+		body, err := json.Marshal(svc)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Post(serverAddr+"/v1/services", "application/json", bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		io.Copy(os.Stdout, resp.Body)
+		return nil
+	},
+}
+
+func init() {
+	serviceAddCmd.Flags().StringVar(&serviceAddID, "id", "", "service id")
+	serviceAddCmd.Flags().StringVar(&serviceAddEndpoint, "endpoint", "", "service endpoint")
+	serviceAddCmd.Flags().StringVar(&serviceAddAPIKey, "apikey", "", "API key")
+	serviceAddCmd.MarkFlagRequired("id")
+	serviceAddCmd.MarkFlagRequired("endpoint")
+	serviceAddCmd.MarkFlagRequired("apikey")
+	rootCmd.AddCommand(serviceAddCmd)
+}

--- a/cmd/bifrost/service_delete.go
+++ b/cmd/bifrost/service_delete.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+var serviceDeleteCmd = &cobra.Command{
+	Use:   "service-delete [id]",
+	Short: "Delete a service",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		req, err := http.NewRequest(http.MethodDelete, serverAddr+"/v1/services/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		fmt.Println("deleted")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(serviceDeleteCmd)
+}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,12 @@ func main() {
 		r.Post("/keys", routes.CreateKey)
 		r.Delete("/keys/{id}", routes.DeleteKey)
 
+		r.Post("/services", routes.CreateService)
+		r.Delete("/services/{id}", routes.DeleteService)
+
 		r.With(m.RateLimitMiddleware()).Post("/rate", v1.SayHello)
+
+		r.Handle("/proxy/{rest:.*}", http.HandlerFunc(v1.Proxy))
 	})
 
 	http.ListenAndServe(config.ServerPort(), r)

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -1,0 +1,8 @@
+package services
+
+// Service represents an upstream service to which requests can be proxied.
+type Service struct {
+	ID       string `json:"id"`
+	Endpoint string `json:"endpoint"`
+	APIKey   string `json:"api_key"`
+}

--- a/pkg/services/store.go
+++ b/pkg/services/store.go
@@ -1,0 +1,56 @@
+package services
+
+import (
+	"errors"
+	"sync"
+)
+
+// Store provides concurrency-safe storage for Service definitions.
+type Store struct {
+	mu       sync.RWMutex
+	services map[string]Service
+}
+
+// NewStore creates an initialized Store.
+func NewStore() *Store {
+	return &Store{services: make(map[string]Service)}
+}
+
+// Create inserts a new Service. Returns an error if the ID already exists.
+func (s *Store) Create(svc Service) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.services[svc.ID]; ok {
+		return ErrServiceExists
+	}
+	s.services[svc.ID] = svc
+	return nil
+}
+
+// Get retrieves a Service by ID.
+func (s *Store) Get(id string) (Service, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	svc, ok := s.services[id]
+	if !ok {
+		return Service{}, ErrServiceNotFound
+	}
+	return svc, nil
+}
+
+// Delete removes a Service.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.services[id]; !ok {
+		return ErrServiceNotFound
+	}
+	delete(s.services, id)
+	return nil
+}
+
+// Error definitions for Store operations.
+var (
+	ErrServiceNotFound = errors.New("service not found")
+	ErrServiceExists   = errors.New("service already exists")
+)

--- a/routes/services.go
+++ b/routes/services.go
@@ -1,0 +1,49 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/FokusInternal/bifrost/pkg/services"
+)
+
+// ServiceStore holds defined services in memory.
+var ServiceStore = services.NewStore()
+
+// CreateService handles POST /services to store a new Service.
+func CreateService(w http.ResponseWriter, r *http.Request) {
+	var s services.Service
+	if err := json.NewDecoder(r.Body).Decode(&s); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if err := ServiceStore.Create(s); err != nil {
+		switch err {
+		case services.ErrServiceExists:
+			http.Error(w, "service already exists", http.StatusConflict)
+		default:
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(s)
+}
+
+// DeleteService handles DELETE /services/{id} to remove a service.
+func DeleteService(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := ServiceStore.Delete(id); err != nil {
+		switch err {
+		case services.ErrServiceNotFound:
+			http.Error(w, "not found", http.StatusNotFound)
+		default:
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/routes/v1/proxy.go
+++ b/routes/v1/proxy.go
@@ -1,0 +1,64 @@
+package v1
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/FokusInternal/bifrost/pkg/keys"
+	"github.com/FokusInternal/bifrost/pkg/services"
+	routes "github.com/FokusInternal/bifrost/routes"
+)
+
+// Proxy forwards the request to the target service determined by the provided
+// virtual key. The key should be supplied via the X-Virtual-Key header.
+func Proxy(w http.ResponseWriter, r *http.Request) {
+	keyID := r.Header.Get("X-Virtual-Key")
+	if keyID == "" {
+		http.Error(w, "missing key", http.StatusUnauthorized)
+		return
+	}
+
+	k, err := routes.KeyStore.Get(keyID)
+	if err != nil {
+		if err == keys.ErrKeyNotFound {
+			http.Error(w, "invalid key", http.StatusUnauthorized)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	if time.Now().After(k.ExpiresAt) {
+		http.Error(w, "key expired", http.StatusUnauthorized)
+		return
+	}
+
+	svc, err := routes.ServiceStore.Get(k.Target)
+	if err != nil {
+		if err == services.ErrServiceNotFound {
+			http.Error(w, "service not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	target, err := url.Parse(svc.Endpoint)
+	if err != nil {
+		http.Error(w, "bad service endpoint", http.StatusInternalServerError)
+		return
+	}
+
+	// Trim /v1/proxy prefix from the path.
+	prefix := "/v1/proxy"
+	r.URL.Path = strings.TrimPrefix(r.URL.Path, prefix)
+
+	r.Header.Set("X-API-Key", svc.APIKey)
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	r.Host = target.Host
+	proxy.ServeHTTP(w, r)
+}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -1,0 +1,51 @@
+package tests
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/FokusInternal/bifrost/pkg/keys"
+	"github.com/FokusInternal/bifrost/pkg/services"
+	routes "github.com/FokusInternal/bifrost/routes"
+)
+
+func TestProxy(t *testing.T) {
+	routes.ServiceStore = services.NewStore()
+	routes.KeyStore = keys.NewStore()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "real" {
+			t.Fatalf("missing injected api key")
+		}
+		if r.URL.Path != "/backend" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		io.WriteString(w, "proxied")
+	}))
+	defer backend.Close()
+
+	svc := services.Service{ID: "svc", Endpoint: backend.URL, APIKey: "real"}
+	if err := routes.ServiceStore.Create(svc); err != nil {
+		t.Fatalf("seed service: %v", err)
+	}
+	k := keys.VirtualKey{ID: "vkey", Target: svc.ID, Scope: "test", ExpiresAt: time.Now().Add(time.Hour)}
+	if err := routes.KeyStore.Create(k); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	router := setupRouter()
+	req := httptest.NewRequest(http.MethodGet, "/v1/proxy/backend", nil)
+	req.Header.Set("X-Virtual-Key", k.ID)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if body := rr.Body.String(); body != "proxied" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -20,6 +20,9 @@ func setupRouter() http.Handler {
 		r.Get("/hello", v1.SayHello)
 		r.Post("/keys", routes.CreateKey)
 		r.Delete("/keys/{id}", routes.DeleteKey)
+		r.Post("/services", routes.CreateService)
+		r.Delete("/services/{id}", routes.DeleteService)
+		r.Handle("/proxy/{rest:.*}", http.HandlerFunc(v1.Proxy))
 	})
 	return r
 }

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/FokusInternal/bifrost/pkg/services"
+	routes "github.com/FokusInternal/bifrost/routes"
+)
+
+func TestCreateService(t *testing.T) {
+	routes.ServiceStore = services.NewStore()
+	router := setupRouter()
+
+	svc := services.Service{ID: "svc", Endpoint: "http://example.com", APIKey: "k"}
+	body, _ := json.Marshal(svc)
+	req := httptest.NewRequest(http.MethodPost, "/v1/services", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rr.Code)
+	}
+
+	var resp services.Service
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ID != svc.ID {
+		t.Fatalf("expected ID %s, got %s", svc.ID, resp.ID)
+	}
+}
+
+func TestDeleteService(t *testing.T) {
+	routes.ServiceStore = services.NewStore()
+	svc := services.Service{ID: "dead", Endpoint: "http://example.com", APIKey: "k"}
+	if err := routes.ServiceStore.Create(svc); err != nil {
+		t.Fatalf("failed to seed store: %v", err)
+	}
+	router := setupRouter()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/services/"+svc.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rr.Code)
+	}
+	if _, err := routes.ServiceStore.Get(svc.ID); err != services.ErrServiceNotFound {
+		t.Fatalf("service was not deleted")
+	}
+}


### PR DESCRIPTION
## Summary
- manage services via CRUD store and HTTP routes
- expose proxy that injects real API key based on virtual key
- add CLI helpers `service-add` and `service-delete`
- document new commands and API
- test service endpoints and proxy logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6856a7cc2094832ab38c0117155e565c