### PR TITLE
Introduce root key management

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Fast, type-safe, and built for performance and extensibility.
 ## CLI Usage
 You can manage virtual keys from the command line with the `bifrost` tool.
 The commands interact with the running HTTP API by default. Before issuing
-keys you must register a root key and then associate services with it using
-`rootkey-add` and `service-add`.
+keys you must register a root key (or update it later) and then associate services with it using
+`rootkey-add`, `rootkey-update` and `service-add`.
 
 The `--target` flag on `issue` refers to the service ID provided when calling
 `service-add`.
@@ -67,6 +67,9 @@ The `--target` flag on `issue` refers to the service ID provided when calling
 ```bash
 # register a root key
 go run ./cmd/bifrost rootkey-add --id root --apikey SECRET
+
+# update the root key without downtime
+go run ./cmd/bifrost rootkey-update --id root --apikey NEWSECRET
 
 # register a service
 go run ./cmd/bifrost service-add --id svc --endpoint http://localhost:8081 --rootkey root

--- a/README.md
+++ b/README.md
@@ -58,15 +58,18 @@ Fast, type-safe, and built for performance and extensibility.
 ## CLI Usage
 You can manage virtual keys from the command line with the `bifrost` tool.
 The commands interact with the running HTTP API by default. Before issuing
-keys you must register the upstream service along with its API key using
-`service-add`.
+keys you must register a root key and then associate services with it using
+`rootkey-add` and `service-add`.
 
 The `--target` flag on `issue` refers to the service ID provided when calling
 `service-add`.
 
 ```bash
+# register a root key
+go run ./cmd/bifrost rootkey-add --id root --apikey SECRET
+
 # register a service
-go run ./cmd/bifrost service-add --id svc --endpoint http://localhost:8081 --apikey SECRET
+go run ./cmd/bifrost service-add --id svc --endpoint http://localhost:8081 --rootkey root
 
 # issue a new key for that service
 go run ./cmd/bifrost issue --id mykey --target svc --scope read --ttl 10m
@@ -76,6 +79,9 @@ go run ./cmd/bifrost revoke mykey
 
 # delete a service
 go run ./cmd/bifrost service-delete svc
+
+# delete the root key
+go run ./cmd/bifrost rootkey-delete root
 ```
 
 Use `--addr` to specify a custom API address if the server is not running on
@@ -86,8 +92,11 @@ Below is a minimal workflow showing how to register a service, issue a key and
 then proxy a request using that key.
 
 ```bash
+# add a root key
+go run ./cmd/bifrost rootkey-add --id demo-root --apikey SECRET
+
 # add the upstream service
-go run ./cmd/bifrost service-add --id demo --endpoint http://localhost:8081 --apikey SECRET
+go run ./cmd/bifrost service-add --id demo --endpoint http://localhost:8081 --rootkey demo-root
 
 # create a virtual key that targets that service
 go run ./cmd/bifrost issue --id demo-key --target demo --ttl 5m
@@ -139,7 +148,7 @@ Example:
 ```bash
 curl -X POST http://localhost:3333/v1/services \
   -H 'Content-Type: application/json' \
-  -d '{"id":"svc","endpoint":"http://localhost:8081","api_key":"SECRET"}'
+  -d '{"id":"svc","endpoint":"http://localhost:8081","root_key_id":"root"}'
 ```
 
 ### Delete a service

--- a/cmd/bifrost/rootkey_add.go
+++ b/cmd/bifrost/rootkey_add.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/FokusInternal/bifrost/pkg/rootkeys"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rootKeyAddID     string
+	rootKeyAddAPIKey string
+)
+
+var rootKeyAddCmd = &cobra.Command{
+	Use:   "rootkey-add",
+	Short: "Add a root key",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rk := rootkeys.RootKey{ID: rootKeyAddID, APIKey: rootKeyAddAPIKey}
+		body, err := json.Marshal(rk)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Post(serverAddr+"/v1/rootkeys", "application/json", bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		io.Copy(os.Stdout, resp.Body)
+		return nil
+	},
+}
+
+func init() {
+	rootKeyAddCmd.Flags().StringVar(&rootKeyAddID, "id", "", "root key id")
+	rootKeyAddCmd.Flags().StringVar(&rootKeyAddAPIKey, "apikey", "", "API key")
+	rootKeyAddCmd.MarkFlagRequired("id")
+	rootKeyAddCmd.MarkFlagRequired("apikey")
+	rootCmd.AddCommand(rootKeyAddCmd)
+}

--- a/cmd/bifrost/rootkey_delete.go
+++ b/cmd/bifrost/rootkey_delete.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+)
+
+var rootKeyDeleteCmd = &cobra.Command{
+	Use:   "rootkey-delete [id]",
+	Short: "Delete a root key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		req, err := http.NewRequest(http.MethodDelete, serverAddr+"/v1/rootkeys/"+args[0], nil)
+		if err != nil {
+			return err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		fmt.Println("deleted")
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(rootKeyDeleteCmd)
+}

--- a/cmd/bifrost/rootkey_update.go
+++ b/cmd/bifrost/rootkey_update.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/FokusInternal/bifrost/pkg/rootkeys"
+	"github.com/spf13/cobra"
+)
+
+var (
+	rootKeyUpdateID     string
+	rootKeyUpdateAPIKey string
+)
+
+var rootKeyUpdateCmd = &cobra.Command{
+	Use:   "rootkey-update",
+	Short: "Update a root key",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rk := rootkeys.RootKey{ID: rootKeyUpdateID, APIKey: rootKeyUpdateAPIKey}
+		body, err := json.Marshal(rk)
+		if err != nil {
+			return err
+		}
+		req, err := http.NewRequest(http.MethodPut, serverAddr+"/v1/rootkeys/"+rootKeyUpdateID, bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		io.Copy(os.Stdout, resp.Body)
+		return nil
+	},
+}
+
+func init() {
+	rootKeyUpdateCmd.Flags().StringVar(&rootKeyUpdateID, "id", "", "root key id")
+	rootKeyUpdateCmd.Flags().StringVar(&rootKeyUpdateAPIKey, "apikey", "", "API key")
+	rootKeyUpdateCmd.MarkFlagRequired("id")
+	rootKeyUpdateCmd.MarkFlagRequired("apikey")
+	rootCmd.AddCommand(rootKeyUpdateCmd)
+}

--- a/cmd/bifrost/service_add.go
+++ b/cmd/bifrost/service_add.go
@@ -13,16 +13,16 @@ import (
 )
 
 var (
-	serviceAddID       string
-	serviceAddEndpoint string
-	serviceAddAPIKey   string
+	serviceAddID        string
+	serviceAddEndpoint  string
+	serviceAddRootKeyID string
 )
 
 var serviceAddCmd = &cobra.Command{
 	Use:   "service-add",
 	Short: "Add a service",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		svc := services.Service{ID: serviceAddID, Endpoint: serviceAddEndpoint, APIKey: serviceAddAPIKey}
+		svc := services.Service{ID: serviceAddID, Endpoint: serviceAddEndpoint, RootKeyID: serviceAddRootKeyID}
 		body, err := json.Marshal(svc)
 		if err != nil {
 			return err
@@ -44,9 +44,9 @@ var serviceAddCmd = &cobra.Command{
 func init() {
 	serviceAddCmd.Flags().StringVar(&serviceAddID, "id", "", "service id")
 	serviceAddCmd.Flags().StringVar(&serviceAddEndpoint, "endpoint", "", "service endpoint")
-	serviceAddCmd.Flags().StringVar(&serviceAddAPIKey, "apikey", "", "API key")
+	serviceAddCmd.Flags().StringVar(&serviceAddRootKeyID, "rootkey", "", "root key id")
 	serviceAddCmd.MarkFlagRequired("id")
 	serviceAddCmd.MarkFlagRequired("endpoint")
-	serviceAddCmd.MarkFlagRequired("apikey")
+	serviceAddCmd.MarkFlagRequired("rootkey")
 	rootCmd.AddCommand(serviceAddCmd)
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ func main() {
 		r.Post("/keys", routes.CreateKey)
 		r.Delete("/keys/{id}", routes.DeleteKey)
 
+		r.Post("/rootkeys", routes.CreateRootKey)
+		r.Delete("/rootkeys/{id}", routes.DeleteRootKey)
+
 		r.Post("/services", routes.CreateService)
 		r.Delete("/services/{id}", routes.DeleteService)
 

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 		r.Delete("/keys/{id}", routes.DeleteKey)
 
 		r.Post("/rootkeys", routes.CreateRootKey)
+		r.Put("/rootkeys/{id}", routes.UpdateRootKey)
 		r.Delete("/rootkeys/{id}", routes.DeleteRootKey)
 
 		r.Post("/services", routes.CreateService)

--- a/pkg/rootkeys/rootkey.go
+++ b/pkg/rootkeys/rootkey.go
@@ -1,0 +1,7 @@
+package rootkeys
+
+// RootKey represents a real API key stored separately from services.
+type RootKey struct {
+	ID     string `json:"id"`
+	APIKey string `json:"api_key"`
+}

--- a/pkg/rootkeys/store.go
+++ b/pkg/rootkeys/store.go
@@ -49,6 +49,17 @@ func (s *Store) Delete(id string) error {
 	return nil
 }
 
+// Update replaces an existing RootKey.
+func (s *Store) Update(k RootKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.keys[k.ID]; !ok {
+		return ErrKeyNotFound
+	}
+	s.keys[k.ID] = k
+	return nil
+}
+
 // Error definitions for store operations.
 var (
 	ErrKeyNotFound = errors.New("root key not found")

--- a/pkg/rootkeys/store.go
+++ b/pkg/rootkeys/store.go
@@ -1,0 +1,56 @@
+package rootkeys
+
+import (
+	"errors"
+	"sync"
+)
+
+// Store keeps RootKeys in memory with concurrency safety.
+type Store struct {
+	mu   sync.RWMutex
+	keys map[string]RootKey
+}
+
+// NewStore creates an initialized Store.
+func NewStore() *Store {
+	return &Store{keys: make(map[string]RootKey)}
+}
+
+// Create inserts a new RootKey. Returns error if ID already exists.
+func (s *Store) Create(k RootKey) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.keys[k.ID]; ok {
+		return ErrKeyExists
+	}
+	s.keys[k.ID] = k
+	return nil
+}
+
+// Get retrieves a RootKey by ID.
+func (s *Store) Get(id string) (RootKey, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	k, ok := s.keys[id]
+	if !ok {
+		return RootKey{}, ErrKeyNotFound
+	}
+	return k, nil
+}
+
+// Delete removes a RootKey from the store.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.keys[id]; !ok {
+		return ErrKeyNotFound
+	}
+	delete(s.keys, id)
+	return nil
+}
+
+// Error definitions for store operations.
+var (
+	ErrKeyNotFound = errors.New("root key not found")
+	ErrKeyExists   = errors.New("root key already exists")
+)

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -1,8 +1,9 @@
 package services
 
 // Service represents an upstream service to which requests can be proxied.
+// Service represents an upstream service to which requests can be proxied.
 type Service struct {
-	ID       string `json:"id"`
-	Endpoint string `json:"endpoint"`
-	APIKey   string `json:"api_key"`
+	ID        string `json:"id"`
+	Endpoint  string `json:"endpoint"`
+	RootKeyID string `json:"root_key_id"`
 }

--- a/routes/rootkeys.go
+++ b/routes/rootkeys.go
@@ -1,0 +1,49 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/FokusInternal/bifrost/pkg/rootkeys"
+)
+
+// RootKeyStore holds active root keys in memory.
+var RootKeyStore = rootkeys.NewStore()
+
+// CreateRootKey handles POST /rootkeys to store a new root key.
+func CreateRootKey(w http.ResponseWriter, r *http.Request) {
+	var k rootkeys.RootKey
+	if err := json.NewDecoder(r.Body).Decode(&k); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if err := RootKeyStore.Create(k); err != nil {
+		switch err {
+		case rootkeys.ErrKeyExists:
+			http.Error(w, "root key already exists", http.StatusConflict)
+		default:
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(k)
+}
+
+// DeleteRootKey handles DELETE /rootkeys/{id} to remove a root key.
+func DeleteRootKey(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := RootKeyStore.Delete(id); err != nil {
+		switch err {
+		case rootkeys.ErrKeyNotFound:
+			http.Error(w, "not found", http.StatusNotFound)
+		default:
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/routes/services.go
+++ b/routes/services.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/FokusInternal/bifrost/pkg/rootkeys"
 	"github.com/FokusInternal/bifrost/pkg/services"
 )
 
@@ -17,6 +18,14 @@ func CreateService(w http.ResponseWriter, r *http.Request) {
 	var s services.Service
 	if err := json.NewDecoder(r.Body).Decode(&s); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if _, err := RootKeyStore.Get(s.RootKeyID); err != nil {
+		if err == rootkeys.ErrKeyNotFound {
+			http.Error(w, "root key not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	if err := ServiceStore.Create(s); err != nil {

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/FokusInternal/bifrost/pkg/keys"
+	"github.com/FokusInternal/bifrost/pkg/rootkeys"
 	"github.com/FokusInternal/bifrost/pkg/services"
 	routes "github.com/FokusInternal/bifrost/routes"
 )
@@ -17,7 +18,12 @@ import (
 func TestCreateKey(t *testing.T) {
 	routes.KeyStore = keys.NewStore()
 	routes.ServiceStore = services.NewStore()
-	svc := services.Service{ID: "svc", Endpoint: "http://example.com", APIKey: "k"}
+	routes.RootKeyStore = rootkeys.NewStore()
+	rk := rootkeys.RootKey{ID: "rk", APIKey: "k"}
+	if err := routes.RootKeyStore.Create(rk); err != nil {
+		t.Fatalf("seed rootkey: %v", err)
+	}
+	svc := services.Service{ID: "svc", Endpoint: "http://example.com", RootKeyID: rk.ID}
 	if err := routes.ServiceStore.Create(svc); err != nil {
 		t.Fatalf("failed to seed service: %v", err)
 	}
@@ -67,7 +73,12 @@ func TestDeleteKey(t *testing.T) {
 func TestCreateKeyExampleJSON(t *testing.T) {
 	routes.KeyStore = keys.NewStore()
 	routes.ServiceStore = services.NewStore()
-	svc := services.Service{ID: "svc", Endpoint: "http://example.com", APIKey: "k"}
+	routes.RootKeyStore = rootkeys.NewStore()
+	rk := rootkeys.RootKey{ID: "rk2", APIKey: "k"}
+	if err := routes.RootKeyStore.Create(rk); err != nil {
+		t.Fatalf("seed rootkey: %v", err)
+	}
+	svc := services.Service{ID: "svc", Endpoint: "http://example.com", RootKeyID: rk.ID}
 	if err := routes.ServiceStore.Create(svc); err != nil {
 		t.Fatalf("failed to seed service: %v", err)
 	}

--- a/tests/rootkeys_test.go
+++ b/tests/rootkeys_test.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/FokusInternal/bifrost/pkg/rootkeys"
+	routes "github.com/FokusInternal/bifrost/routes"
+)
+
+func TestCreateRootKey(t *testing.T) {
+	routes.RootKeyStore = rootkeys.NewStore()
+	router := setupRouter()
+
+	rk := rootkeys.RootKey{ID: "rk", APIKey: "secret"}
+	body, _ := json.Marshal(rk)
+	req := httptest.NewRequest(http.MethodPost, "/v1/rootkeys", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", rr.Code)
+	}
+
+	var resp rootkeys.RootKey
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.ID != rk.ID {
+		t.Fatalf("expected ID %s, got %s", rk.ID, resp.ID)
+	}
+}
+
+func TestDeleteRootKey(t *testing.T) {
+	routes.RootKeyStore = rootkeys.NewStore()
+	rk := rootkeys.RootKey{ID: "dead", APIKey: "k"}
+	if err := routes.RootKeyStore.Create(rk); err != nil {
+		t.Fatalf("failed to seed store: %v", err)
+	}
+	router := setupRouter()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/rootkeys/"+rk.ID, nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", rr.Code)
+	}
+	if _, err := routes.RootKeyStore.Get(rk.ID); err != rootkeys.ErrKeyNotFound {
+		t.Fatalf("root key was not deleted")
+	}
+}

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -20,6 +20,8 @@ func setupRouter() http.Handler {
 		r.Get("/hello", v1.SayHello)
 		r.Post("/keys", routes.CreateKey)
 		r.Delete("/keys/{id}", routes.DeleteKey)
+		r.Post("/rootkeys", routes.CreateRootKey)
+		r.Delete("/rootkeys/{id}", routes.DeleteRootKey)
 		r.Post("/services", routes.CreateService)
 		r.Delete("/services/{id}", routes.DeleteService)
 		r.Handle("/proxy/{rest:.*}", http.HandlerFunc(v1.Proxy))

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -21,6 +21,7 @@ func setupRouter() http.Handler {
 		r.Post("/keys", routes.CreateKey)
 		r.Delete("/keys/{id}", routes.DeleteKey)
 		r.Post("/rootkeys", routes.CreateRootKey)
+		r.Put("/rootkeys/{id}", routes.UpdateRootKey)
 		r.Delete("/rootkeys/{id}", routes.DeleteRootKey)
 		r.Post("/services", routes.CreateService)
 		r.Delete("/services/{id}", routes.DeleteService)


### PR DESCRIPTION
## Summary
- manage API keys in new `pkg/rootkeys` package
- add CLI commands to create/delete root keys
- extend services to reference `RootKeyID`
- resolve root keys in proxy
- expose `/v1/rootkeys` endpoints
- update README instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6856b2b92690832ab78fa1776bc54d0b