### PR TITLE
Allow proxy key via query parameter

### DIFF
--- a/routes/v1/proxy.go
+++ b/routes/v1/proxy.go
@@ -18,6 +18,14 @@ import (
 func Proxy(w http.ResponseWriter, r *http.Request) {
 	keyID := r.Header.Get("X-Virtual-Key")
 	if keyID == "" {
+		q := r.URL.Query()
+		keyID = q.Get("key")
+		if keyID != "" {
+			q.Del("key")
+			r.URL.RawQuery = q.Encode()
+		}
+	}
+	if keyID == "" {
 		http.Error(w, "missing key", http.StatusUnauthorized)
 		return
 	}

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -55,3 +55,51 @@ func TestProxy(t *testing.T) {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }
+
+func TestProxyQueryKey(t *testing.T) {
+	routes.ServiceStore = services.NewStore()
+	routes.KeyStore = keys.NewStore()
+	routes.RootKeyStore = rootkeys.NewStore()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "real" {
+			t.Fatalf("missing injected api key")
+		}
+		if r.URL.Path != "/backend" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("key") != "" {
+			t.Fatalf("virtual key leaked in query")
+		}
+		if r.URL.RawQuery != "foo=bar" {
+			t.Fatalf("unexpected query %s", r.URL.RawQuery)
+		}
+		io.WriteString(w, "proxied")
+	}))
+	defer backend.Close()
+
+	rk := rootkeys.RootKey{ID: "rk", APIKey: "real"}
+	if err := routes.RootKeyStore.Create(rk); err != nil {
+		t.Fatalf("seed rootkey: %v", err)
+	}
+	svc := services.Service{ID: "svc", Endpoint: backend.URL, RootKeyID: rk.ID}
+	if err := routes.ServiceStore.Create(svc); err != nil {
+		t.Fatalf("seed service: %v", err)
+	}
+	k := keys.VirtualKey{ID: "vkey", Target: svc.ID, Scope: "test", ExpiresAt: time.Now().Add(time.Hour)}
+	if err := routes.KeyStore.Create(k); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+
+	router := setupRouter()
+	req := httptest.NewRequest(http.MethodGet, "/v1/proxy/backend?key="+k.ID+"&foo=bar", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if body := rr.Body.String(); body != "proxied" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary
- support virtual key in `/v1/proxy` querystring
- strip `key` query parameter before forwarding
- add test for reading key from query string

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6856ca33839c832a97906e341c4907c0