### PR TITLE
strip forwarded X-Virtual-Key header

### DIFF
--- a/routes/v1/proxy.go
+++ b/routes/v1/proxy.go
@@ -17,6 +17,7 @@ import (
 // virtual key. The key should be supplied via the X-Virtual-Key header.
 func Proxy(w http.ResponseWriter, r *http.Request) {
 	keyID := r.Header.Get("X-Virtual-Key")
+	r.Header.Del("X-Virtual-Key")
 	if keyID == "" {
 		q := r.URL.Query()
 		keyID = q.Get("key")


### PR DESCRIPTION
## Summary
- remove `X-Virtual-Key` header once the value is read
- forward request as before through `httputil.NewSingleHostReverseProxy`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6856cbfb251c832aba2d1b85497e8a99