### PR TITLE
Add proxy subtests for header and query modes

### DIFF
--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -14,92 +14,71 @@ import (
 )
 
 func TestProxy(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.KeyStore = keys.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-API-Key") != "real" {
-			t.Fatalf("missing injected api key")
-		}
-		if r.URL.Path != "/backend" {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		io.WriteString(w, "proxied")
-	}))
-	defer backend.Close()
-
-	rk := rootkeys.RootKey{ID: "rk", APIKey: "real"}
-	if err := routes.RootKeyStore.Create(rk); err != nil {
-		t.Fatalf("seed rootkey: %v", err)
-	}
-	svc := services.Service{ID: "svc", Endpoint: backend.URL, RootKeyID: rk.ID}
-	if err := routes.ServiceStore.Create(svc); err != nil {
-		t.Fatalf("seed service: %v", err)
-	}
-	k := keys.VirtualKey{ID: "vkey", Target: svc.ID, Scope: "test", ExpiresAt: time.Now().Add(time.Hour)}
-	if err := routes.KeyStore.Create(k); err != nil {
-		t.Fatalf("seed key: %v", err)
+	cases := []struct {
+		name     string
+		useQuery bool
+	}{
+		{name: "header", useQuery: false},
+		{name: "query", useQuery: true},
 	}
 
-	router := setupRouter()
-	req := httptest.NewRequest(http.MethodGet, "/v1/proxy/backend", nil)
-	req.Header.Set("X-Virtual-Key", k.ID)
-	rr := httptest.NewRecorder()
-	router.ServeHTTP(rr, req)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			routes.ServiceStore = services.NewStore()
+			routes.KeyStore = keys.NewStore()
+			routes.RootKeyStore = rootkeys.NewStore()
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	if body := rr.Body.String(); body != "proxied" {
-		t.Fatalf("unexpected body: %s", body)
-	}
-}
+			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("X-API-Key") != "real" {
+					t.Fatalf("missing injected api key")
+				}
+				if r.Header.Get("X-Virtual-Key") != "" {
+					t.Fatalf("virtual key header leaked")
+				}
+				if r.URL.Path != "/backend" {
+					t.Fatalf("unexpected path %s", r.URL.Path)
+				}
+				if r.URL.Query().Get("key") != "" {
+					t.Fatalf("virtual key leaked in query")
+				}
+				if r.URL.RawQuery != "foo=bar" {
+					t.Fatalf("unexpected query %s", r.URL.RawQuery)
+				}
+				io.WriteString(w, "proxied")
+			}))
+			defer backend.Close()
 
-func TestProxyQueryKey(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.KeyStore = keys.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
+			rk := rootkeys.RootKey{ID: "rk", APIKey: "real"}
+			if err := routes.RootKeyStore.Create(rk); err != nil {
+				t.Fatalf("seed rootkey: %v", err)
+			}
+			svc := services.Service{ID: "svc", Endpoint: backend.URL, RootKeyID: rk.ID}
+			if err := routes.ServiceStore.Create(svc); err != nil {
+				t.Fatalf("seed service: %v", err)
+			}
+			k := keys.VirtualKey{ID: "vkey", Target: svc.ID, Scope: "test", ExpiresAt: time.Now().Add(time.Hour)}
+			if err := routes.KeyStore.Create(k); err != nil {
+				t.Fatalf("seed key: %v", err)
+			}
 
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-API-Key") != "real" {
-			t.Fatalf("missing injected api key")
-		}
-		if r.URL.Path != "/backend" {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
-		if r.URL.Query().Get("key") != "" {
-			t.Fatalf("virtual key leaked in query")
-		}
-		if r.URL.RawQuery != "foo=bar" {
-			t.Fatalf("unexpected query %s", r.URL.RawQuery)
-		}
-		io.WriteString(w, "proxied")
-	}))
-	defer backend.Close()
+			router := setupRouter()
+			url := "/v1/proxy/backend?foo=bar"
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			if tc.useQuery {
+				req = httptest.NewRequest(http.MethodGet, "/v1/proxy/backend?key="+k.ID+"&foo=bar", nil)
+			} else {
+				req.Header.Set("X-Virtual-Key", k.ID)
+			}
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
 
-	rk := rootkeys.RootKey{ID: "rk", APIKey: "real"}
-	if err := routes.RootKeyStore.Create(rk); err != nil {
-		t.Fatalf("seed rootkey: %v", err)
-	}
-	svc := services.Service{ID: "svc", Endpoint: backend.URL, RootKeyID: rk.ID}
-	if err := routes.ServiceStore.Create(svc); err != nil {
-		t.Fatalf("seed service: %v", err)
-	}
-	k := keys.VirtualKey{ID: "vkey", Target: svc.ID, Scope: "test", ExpiresAt: time.Now().Add(time.Hour)}
-	if err := routes.KeyStore.Create(k); err != nil {
-		t.Fatalf("seed key: %v", err)
-	}
-
-	router := setupRouter()
-	req := httptest.NewRequest(http.MethodGet, "/v1/proxy/backend?key="+k.ID+"&foo=bar", nil)
-	rr := httptest.NewRecorder()
-	router.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d", rr.Code)
-	}
-	if body := rr.Body.String(); body != "proxied" {
-		t.Fatalf("unexpected body: %s", body)
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rr.Code)
+			}
+			if body := rr.Body.String(); body != "proxied" {
+				t.Fatalf("unexpected body: %s", body)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- refactor proxy tests to use subtests
- add assertions that virtual key header is stripped before forwarding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6856cd9db7f8832aaad2dfbdf8345403