### PR TITLE
Add key scope validation and expiration checks

### DIFF
--- a/pkg/keys/scope.go
+++ b/pkg/keys/scope.go
@@ -1,0 +1,18 @@
+package keys
+
+// Allowed scopes for virtual keys.
+const (
+	ScopeRead  = "read"
+	ScopeWrite = "write"
+)
+
+var allowedScopes = map[string]struct{}{
+	ScopeRead:  {},
+	ScopeWrite: {},
+}
+
+// ValidateScope returns true if s matches one of the allowed scopes.
+func ValidateScope(s string) bool {
+	_, ok := allowedScopes[s]
+	return ok
+}

--- a/routes/keys.go
+++ b/routes/keys.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -18,6 +19,14 @@ func CreateKey(w http.ResponseWriter, r *http.Request) {
 	var k keys.VirtualKey
 	if err := json.NewDecoder(r.Body).Decode(&k); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if !keys.ValidateScope(k.Scope) {
+		http.Error(w, "invalid scope", http.StatusBadRequest)
+		return
+	}
+	if !k.ExpiresAt.After(time.Now()) {
+		http.Error(w, "expires_at must be in the future", http.StatusBadRequest)
 		return
 	}
 	if _, err := ServiceStore.Get(k.Target); err != nil {

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -29,7 +29,7 @@ func TestCreateKey(t *testing.T) {
 	}
 	router := setupRouter()
 
-	k := keys.VirtualKey{ID: "abc", Scope: "test", Target: svc.ID, ExpiresAt: time.Now()}
+	k := keys.VirtualKey{ID: "abc", Scope: "read", Target: svc.ID, ExpiresAt: time.Now().Add(time.Hour)}
 	body, _ := json.Marshal(k)
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	rr := httptest.NewRecorder()
@@ -84,7 +84,7 @@ func TestCreateKeyExampleJSON(t *testing.T) {
 	}
 	router := setupRouter()
 
-	payload := `{"id":"jsonex","scope":"read","target":"svc","expires_at":"2024-01-02T15:04:05Z"}`
+	payload := `{"id":"jsonex","scope":"read","target":"svc","expires_at":"2050-01-02T15:04:05Z"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", strings.NewReader(payload))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
@@ -98,7 +98,7 @@ func TestCreateKeyExampleJSON(t *testing.T) {
 		t.Fatalf("failed to decode response: %v", err)
 	}
 
-	expTime, _ := time.Parse(time.RFC3339, "2024-01-02T15:04:05Z")
+	expTime, _ := time.Parse(time.RFC3339, "2050-01-02T15:04:05Z")
 	if resp.ID != "jsonex" || !resp.ExpiresAt.Equal(expTime) || resp.Scope != "read" || resp.Target != "svc" {
 		t.Fatalf("unexpected response: %#v", resp)
 	}

--- a/tests/routes_errors_test.go
+++ b/tests/routes_errors_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/FokusInternal/bifrost/pkg/keys"
+	"github.com/FokusInternal/bifrost/pkg/rootkeys"
 	"github.com/FokusInternal/bifrost/pkg/services"
 	routes "github.com/FokusInternal/bifrost/routes"
 )
@@ -33,7 +34,7 @@ func TestCreateKeyInvalidJSON(t *testing.T) {
 
 func TestCreateKeyDuplicate(t *testing.T) {
 	routes.KeyStore = keys.NewStore()
-	k := keys.VirtualKey{ID: "dup", Scope: "test", Target: "svc", ExpiresAt: time.Now()}
+	k := keys.VirtualKey{ID: "dup", Scope: "read", Target: "svc", ExpiresAt: time.Now().Add(time.Hour)}
 	if err := routes.KeyStore.Create(k); err != nil {
 		t.Fatalf("failed to seed store: %v", err)
 	}
@@ -75,7 +76,7 @@ func TestCreateKeyMissingService(t *testing.T) {
 	routes.ServiceStore = services.NewStore()
 	router := setupRouter()
 
-	k := keys.VirtualKey{ID: "nosvc", Scope: "test", Target: "missing", ExpiresAt: time.Now()}
+	k := keys.VirtualKey{ID: "nosvc", Scope: "read", Target: "missing", ExpiresAt: time.Now().Add(time.Hour)}
 	body, _ := json.Marshal(k)
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	rr := httptest.NewRecorder()
@@ -91,5 +92,89 @@ func TestCreateKeyMissingService(t *testing.T) {
 
 	if _, err := routes.KeyStore.Get(k.ID); err != keys.ErrKeyNotFound {
 		t.Fatalf("key should not have been created")
+	}
+}
+
+func TestCreateKeyInvalidScope(t *testing.T) {
+	routes.KeyStore = keys.NewStore()
+	routes.ServiceStore = services.NewStore()
+	routes.RootKeyStore = rootkeys.NewStore()
+	rk := rootkeys.RootKey{ID: "rk-scope", APIKey: "k"}
+	if err := routes.RootKeyStore.Create(rk); err != nil {
+		t.Fatalf("seed rootkey: %v", err)
+	}
+	svc := services.Service{ID: "svc-scope", Endpoint: "http://example.com", RootKeyID: rk.ID}
+	if err := routes.ServiceStore.Create(svc); err != nil {
+		t.Fatalf("failed to seed service: %v", err)
+	}
+	router := setupRouter()
+
+	k := keys.VirtualKey{ID: "badscope", Scope: "unknown", Target: svc.ID, ExpiresAt: time.Now().Add(time.Hour)}
+	body, _ := json.Marshal(k)
+	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+	if body := strings.TrimSpace(rr.Body.String()); body != "invalid scope" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestCreateKeyEmptyScope(t *testing.T) {
+	routes.KeyStore = keys.NewStore()
+	routes.ServiceStore = services.NewStore()
+	routes.RootKeyStore = rootkeys.NewStore()
+	rk := rootkeys.RootKey{ID: "rk-empty", APIKey: "k"}
+	if err := routes.RootKeyStore.Create(rk); err != nil {
+		t.Fatalf("seed rootkey: %v", err)
+	}
+	svc := services.Service{ID: "svc-empty", Endpoint: "http://example.com", RootKeyID: rk.ID}
+	if err := routes.ServiceStore.Create(svc); err != nil {
+		t.Fatalf("failed to seed service: %v", err)
+	}
+	router := setupRouter()
+
+	k := keys.VirtualKey{ID: "emptyscope", Scope: "", Target: svc.ID, ExpiresAt: time.Now().Add(time.Hour)}
+	body, _ := json.Marshal(k)
+	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+	if body := strings.TrimSpace(rr.Body.String()); body != "invalid scope" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestCreateKeyPastExpiration(t *testing.T) {
+	routes.KeyStore = keys.NewStore()
+	routes.ServiceStore = services.NewStore()
+	routes.RootKeyStore = rootkeys.NewStore()
+	rk := rootkeys.RootKey{ID: "rk-exp", APIKey: "k"}
+	if err := routes.RootKeyStore.Create(rk); err != nil {
+		t.Fatalf("seed rootkey: %v", err)
+	}
+	svc := services.Service{ID: "svc-exp", Endpoint: "http://example.com", RootKeyID: rk.ID}
+	if err := routes.ServiceStore.Create(svc); err != nil {
+		t.Fatalf("failed to seed service: %v", err)
+	}
+	router := setupRouter()
+
+	k := keys.VirtualKey{ID: "expired", Scope: "read", Target: svc.ID, ExpiresAt: time.Now().Add(-time.Hour)}
+	body, _ := json.Marshal(k)
+	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+	if body := strings.TrimSpace(rr.Body.String()); body != "expires_at must be in the future" {
+		t.Fatalf("unexpected body: %s", body)
 	}
 }


### PR DESCRIPTION
## Summary
- add allowed scopes and validation helpers
- validate scope and expiration in CreateKey handler
- update key creation tests with future expiry
- test validation failures for invalid scope and expiration

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6856d0cad240832a84cdcde4f67b6432