### PR TITLE
Add Docker Compose helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,13 @@ build:
 
 # run: Execute the main application using Go 1.23.8
 run:
-	go1.23.8 run main.go
+        go1.23.8 run main.go
+
+# compose-up: start Docker Compose environment
+compose-up:
+	docker compose up -d
+
+# compose-down: stop Docker Compose environment
+compose-down:
+	docker compose down
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,19 @@ make setup
 make run
 ```
 
-If you want to exercise the rate‑limit middleware, ensure Redis is running (for example via `docker run -d --name redis-dev -p 6379:6379 redis:7-alpine`).
+If you want to exercise the rate‑limit middleware, ensure Redis is running (for example via `docker run -d --name redis-dev -p 6379:6379 redis:7-alpine`) or start the provided Docker Compose stack:
+
+```bash
+make compose-up
+```
+
+Stop it again with:
+
+```bash
+make compose-down
+```
+
+Use `./test-rate-limitting-compose.sh` to run the rate limit script against this environment.
 
 ## Running Tests
 Run the suite with:

--- a/test-rate-limitting-compose.sh
+++ b/test-rate-limitting-compose.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Start the compose stack
+docker compose up -d
+
+# Give the services a moment to initialize
+sleep 5
+
+# Run the existing rate limit test against the running stack
+./test-rate-limitting.sh
+
+# Tear down the stack after the test
+docker compose down


### PR DESCRIPTION
## Summary
- add `make compose-up` and `compose-down` targets
- provide helper script `test-rate-limitting-compose.sh`
- document how to use these helpers in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68570471dbb0832a82a55e12b0e335d8