### PR TITLE
Fix comment duplication for Service struct

### DIFF
--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -1,7 +1,6 @@
 package services
 
 // Service represents an upstream service to which requests can be proxied.
-// Service represents an upstream service to which requests can be proxied.
 type Service struct {
 	ID        string `json:"id"`
 	Endpoint  string `json:"endpoint"`


### PR DESCRIPTION
## Summary
- dedupe the Service comment in `service.go`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68570481e8f4832a8f92286c2c99e502