### PR TITLE
Fix rate limit script comment and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ make run
 ```
 
 If you want to exercise the rate‑limit middleware, ensure Redis is running (for example via `docker run -d --name redis-dev -p 6379:6379 redis:7-alpine`).
+Then run `./test-rate-limitting.sh` to send a burst of requests against the `/v1/rate` endpoint.
 
 ## Running Tests
 Run the suite with:

--- a/test-rate-limitting.sh
+++ b/test-rate-limitting.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Spinnup a redis before executing requests
+# Spin up a Redis before executing requests
 # docker run -d --name redis-dev -p 6379:6379 redis:7-alpine
 
 for i in {1..30}; do


### PR DESCRIPTION
## Summary
- fix comment in `test-rate-limitting.sh`
- document test script in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68570486b8f0832a98c0c4ada391debe