### PR TITLE
Clean up README compose section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,6 @@ make setup
 make run
 ```
 
-### Docker Compose
-```bash
-make compose-up
-```
-
-Stop it again with:
-
-```bash
-make compose-down
-```
-
-Use `./test-rate-limitting-compose.sh` to run the rate limit script against this environment.
-If you want to exercise the rate‑limit middleware, ensure Redis is running (for example via `docker run -d --name redis-dev -p 6379:6379 redis:7-alpine`).
-Then run `./test-rate-limitting.sh` to send a burst of requests against the `/v1/rate` endpoint.
 
 ## Running with Docker Compose
 


### PR DESCRIPTION
## Summary
- remove short Docker Compose example
- keep the detailed Docker Compose instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68570a12d8f4832aa87154acbc55d18a