### PR TITLE
Add example request to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ go test ./...
 See `test-rate-limitting.sh` for a small script that exercises the rate limit
 middleware against the Compose setup.
 
+## Example Request
+
+Once the server is running you can proxy a request with a virtual key:
+
+```bash
+curl -H "X-Virtual-Key: <key>" http://localhost:3333/v1/proxy/hello
+```
+
+You can also supply the key via the `key` query parameter instead of the header.
+
 ## Running Tests
 Run the suite with:
 ```bash


### PR DESCRIPTION
## Summary
- document how to send a proxied request early in the README
- show cURL example using `X-Virtual-Key` header or `key` query param

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68570a5d6f40832a9d01416e02fb0a3c