### PR TITLE
Add user auth with API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,16 @@ go run ./cmd/bifrost service-delete svc
 
 # delete the root key
 go run ./cmd/bifrost rootkey-delete root
+
+# create an API user
+go run ./cmd/bifrost user-add --id admin
 ```
 
 Use `--addr` to specify a custom API address if the server is not running on
 `http://localhost:3333`.
+
+The generated API key must be provided in the `X-API-Key` or `Authorization`
+header when calling any `/v1` endpoint.
 
 ### End-to-End Example
 Below is a minimal workflow showing how to register a service, issue a key and

--- a/cmd/bifrost/user_add.go
+++ b/cmd/bifrost/user_add.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var userAddID string
+
+var userAddCmd = &cobra.Command{
+	Use:   "user-add",
+	Short: "Create a user and generate an API key",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		payload := map[string]string{"id": userAddID}
+		body, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+		resp, err := http.Post(serverAddr+"/v1/users", "application/json", bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			b, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("server error: %s", bytes.TrimSpace(b))
+		}
+		io.Copy(os.Stdout, resp.Body)
+		return nil
+	},
+}
+
+func init() {
+	userAddCmd.Flags().StringVar(&userAddID, "id", "", "user id")
+	userAddCmd.MarkFlagRequired("id")
+	rootCmd.AddCommand(userAddCmd)
+}

--- a/main.go
+++ b/main.go
@@ -34,7 +34,10 @@ func main() {
 
 	r.Route("/v1", func(r chi.Router) {
 		r.Use(apiVersionCtx("v1"))
+		r.Use(rl.AuthMiddleware())
 		r.Get("/hello", v1.SayHello)
+
+		r.Post("/users", routes.CreateUser)
 
 		r.Post("/keys", routes.CreateKey)
 		r.Delete("/keys/{id}", routes.DeleteKey)

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -1,0 +1,34 @@
+package middlewares
+
+import (
+	"net/http"
+	"strings"
+
+	routes "github.com/farovictor/bifrost/routes"
+)
+
+// AuthMiddleware validates the API key provided by the client.
+func AuthMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			key := r.Header.Get("X-API-Key")
+			if key == "" {
+				auth := r.Header.Get("Authorization")
+				if strings.HasPrefix(auth, "Bearer ") {
+					key = strings.TrimPrefix(auth, "Bearer ")
+				} else {
+					key = auth
+				}
+			}
+			if key == "" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			if _, err := routes.UserStore.GetByAPIKey(key); err != nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/users/store.go
+++ b/pkg/users/store.go
@@ -1,0 +1,84 @@
+package users
+
+import (
+	"errors"
+	"sync"
+)
+
+// Store holds users in memory with concurrency safety.
+type Store struct {
+	mu    sync.RWMutex
+	users map[string]User
+	byKey map[string]User
+}
+
+// NewStore creates an initialized Store.
+func NewStore() *Store {
+	return &Store{users: make(map[string]User), byKey: make(map[string]User)}
+}
+
+// Create inserts a new User. Returns error if ID already exists.
+func (s *Store) Create(u User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.users[u.ID]; ok {
+		return ErrUserExists
+	}
+	s.users[u.ID] = u
+	s.byKey[u.APIKey] = u
+	return nil
+}
+
+// Get retrieves a User by ID.
+func (s *Store) Get(id string) (User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.users[id]
+	if !ok {
+		return User{}, ErrUserNotFound
+	}
+	return u, nil
+}
+
+// GetByAPIKey retrieves a User by its API key.
+func (s *Store) GetByAPIKey(key string) (User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.byKey[key]
+	if !ok {
+		return User{}, ErrUserNotFound
+	}
+	return u, nil
+}
+
+// Delete removes a User.
+func (s *Store) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[id]
+	if !ok {
+		return ErrUserNotFound
+	}
+	delete(s.users, id)
+	delete(s.byKey, u.APIKey)
+	return nil
+}
+
+// Update replaces an existing user.
+func (s *Store) Update(u User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.users[u.ID]; !ok {
+		return ErrUserNotFound
+	}
+	old := s.users[u.ID]
+	delete(s.byKey, old.APIKey)
+	s.users[u.ID] = u
+	s.byKey[u.APIKey] = u
+	return nil
+}
+
+var (
+	ErrUserNotFound = errors.New("user not found")
+	ErrUserExists   = errors.New("user already exists")
+)

--- a/pkg/users/user.go
+++ b/pkg/users/user.go
@@ -1,0 +1,7 @@
+package users
+
+// User represents an API user able to authenticate to Bifrost.
+type User struct {
+	ID     string `json:"id"`
+	APIKey string `json:"api_key"`
+}

--- a/routes/users.go
+++ b/routes/users.go
@@ -1,0 +1,51 @@
+package routes
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+
+	"github.com/farovictor/bifrost/pkg/logging"
+	"github.com/farovictor/bifrost/pkg/users"
+)
+
+// UserStore holds registered users in memory.
+var UserStore = users.NewStore()
+
+// CreateUser handles POST /users and generates an API key.
+func CreateUser(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.ID == "" {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	u := users.User{ID: req.ID, APIKey: generateKey()}
+	if err := UserStore.Create(u); err != nil {
+		switch err {
+		case users.ErrUserExists:
+			http.Error(w, "user already exists", http.StatusConflict)
+		default:
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	logging.Logger.Info().Str("user_id", u.ID).Msg("created user")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(u)
+}
+
+func generateKey() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -9,12 +9,16 @@ import (
 
 	"github.com/farovictor/bifrost/pkg/rootkeys"
 	"github.com/farovictor/bifrost/pkg/services"
+	"github.com/farovictor/bifrost/pkg/users"
 	routes "github.com/farovictor/bifrost/routes"
 )
 
 func TestCreateService(t *testing.T) {
 	routes.ServiceStore = services.NewStore()
 	routes.RootKeyStore = rootkeys.NewStore()
+	routes.UserStore = users.NewStore()
+	u := users.User{ID: "u", APIKey: "secret"}
+	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {
 		t.Fatalf("seed rootkey: %v", err)
@@ -24,6 +28,7 @@ func TestCreateService(t *testing.T) {
 	svc := services.Service{ID: "svc", Endpoint: "http://example.com", RootKeyID: rk.ID}
 	body, _ := json.Marshal(svc)
 	req := httptest.NewRequest(http.MethodPost, "/v1/services", bytes.NewReader(body))
+	req.Header.Set("X-API-Key", u.APIKey)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -43,6 +48,9 @@ func TestCreateService(t *testing.T) {
 func TestDeleteService(t *testing.T) {
 	routes.ServiceStore = services.NewStore()
 	routes.RootKeyStore = rootkeys.NewStore()
+	routes.UserStore = users.NewStore()
+	u := users.User{ID: "u", APIKey: "secret"}
+	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rkdead", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {
 		t.Fatalf("seed rootkey: %v", err)
@@ -53,6 +61,7 @@ func TestDeleteService(t *testing.T) {
 	}
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodDelete, "/v1/services/"+svc.ID, nil)
+	req.Header.Set("X-API-Key", u.APIKey)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 


### PR DESCRIPTION
## Summary
- add new users package with in-memory store
- implement user creation endpoint and CLI command
- add auth middleware and secure `/v1` routes
- update tests to include authentication
- document how to create users and use the API key

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68570ce610dc832a94b16b1fe047cd70