### PR TITLE
Implement membership store

### DIFF
--- a/pkg/orgs/membership.go
+++ b/pkg/orgs/membership.go
@@ -1,0 +1,7 @@
+package orgs
+
+type Membership struct {
+	UserID string `json:"user_id"`
+	OrgID  string `json:"org_id"`
+	Role   string `json:"role"`
+}

--- a/pkg/orgs/membership_store.go
+++ b/pkg/orgs/membership_store.go
@@ -1,0 +1,85 @@
+package orgs
+
+import (
+	"errors"
+	"sync"
+)
+
+// MembershipStore keeps Memberships in memory with concurrency safety.
+type MembershipStore struct {
+	mu          sync.RWMutex
+	memberships map[string]Membership
+}
+
+// NewMembershipStore creates an initialized MembershipStore.
+func NewMembershipStore() *MembershipStore {
+	return &MembershipStore{memberships: make(map[string]Membership)}
+}
+
+func membershipKey(userID, orgID string) string {
+	return userID + ":" + orgID
+}
+
+// Create inserts a new Membership. Returns error if the user/org pair already exists.
+func (s *MembershipStore) Create(m Membership) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := membershipKey(m.UserID, m.OrgID)
+	if _, ok := s.memberships[k]; ok {
+		return ErrMembershipExists
+	}
+	s.memberships[k] = m
+	return nil
+}
+
+// Get retrieves a Membership by user and organization IDs.
+func (s *MembershipStore) Get(userID, orgID string) (Membership, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	k := membershipKey(userID, orgID)
+	m, ok := s.memberships[k]
+	if !ok {
+		return Membership{}, ErrMembershipNotFound
+	}
+	return m, nil
+}
+
+// Delete removes a Membership from the store.
+func (s *MembershipStore) Delete(userID, orgID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := membershipKey(userID, orgID)
+	if _, ok := s.memberships[k]; !ok {
+		return ErrMembershipNotFound
+	}
+	delete(s.memberships, k)
+	return nil
+}
+
+// Update replaces an existing Membership.
+func (s *MembershipStore) Update(m Membership) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := membershipKey(m.UserID, m.OrgID)
+	if _, ok := s.memberships[k]; !ok {
+		return ErrMembershipNotFound
+	}
+	s.memberships[k] = m
+	return nil
+}
+
+// List returns all Memberships currently in the store.
+func (s *MembershipStore) List() []Membership {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Membership, 0, len(s.memberships))
+	for _, m := range s.memberships {
+		out = append(out, m)
+	}
+	return out
+}
+
+var (
+	ErrMembershipNotFound = errors.New("membership not found")
+	ErrMembershipExists   = errors.New("membership already exists")
+)


### PR DESCRIPTION
## Summary
- add membership data structure for orgs
- create in-memory membership store with CRUD operations

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685726086108832a949969bfca51d22b