### PR TITLE
Add org and membership store tests

### DIFF
--- a/routes/orgs.go
+++ b/routes/orgs.go
@@ -1,0 +1,9 @@
+package routes
+
+import "github.com/farovictor/bifrost/pkg/orgs"
+
+// OrgStore holds defined organizations in memory.
+var OrgStore = orgs.NewStore()
+
+// MembershipStore holds organization memberships in memory.
+var MembershipStore = orgs.NewMembershipStore()

--- a/tests/orgs_test.go
+++ b/tests/orgs_test.go
@@ -1,0 +1,104 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/farovictor/bifrost/pkg/orgs"
+	routes "github.com/farovictor/bifrost/routes"
+)
+
+func TestCreateGetOrg(t *testing.T) {
+	routes.OrgStore = orgs.NewStore()
+	o := orgs.Organization{ID: "org1", Name: "Test Org"}
+	if err := routes.OrgStore.Create(o); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := routes.OrgStore.Get(o.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.ID != o.ID || got.Name != o.Name {
+		t.Fatalf("unexpected org: %#v", got)
+	}
+}
+
+func TestUpdateOrg(t *testing.T) {
+	routes.OrgStore = orgs.NewStore()
+	o := orgs.Organization{ID: "org1", Name: "Old"}
+	if err := routes.OrgStore.Create(o); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	updated := orgs.Organization{ID: "org1", Name: "New"}
+	if err := routes.OrgStore.Update(updated); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, err := routes.OrgStore.Get(o.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "New" {
+		t.Fatalf("update did not persist")
+	}
+}
+
+func TestDeleteOrg(t *testing.T) {
+	routes.OrgStore = orgs.NewStore()
+	o := orgs.Organization{ID: "org1", Name: "Del"}
+	if err := routes.OrgStore.Create(o); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := routes.OrgStore.Delete(o.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := routes.OrgStore.Get(o.ID); err != orgs.ErrOrgNotFound {
+		t.Fatalf("org not removed")
+	}
+}
+
+func TestCreateGetMembership(t *testing.T) {
+	routes.MembershipStore = orgs.NewMembershipStore()
+	m := orgs.Membership{UserID: "u1", OrgID: "o1", Role: orgs.RoleMember}
+	if err := routes.MembershipStore.Create(m); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := routes.MembershipStore.Get(m.UserID, m.OrgID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got != m {
+		t.Fatalf("unexpected membership: %#v", got)
+	}
+}
+
+func TestUpdateMembership(t *testing.T) {
+	routes.MembershipStore = orgs.NewMembershipStore()
+	m := orgs.Membership{UserID: "u1", OrgID: "o1", Role: orgs.RoleMember}
+	if err := routes.MembershipStore.Create(m); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	m.Role = orgs.RoleAdmin
+	if err := routes.MembershipStore.Update(m); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	got, err := routes.MembershipStore.Get(m.UserID, m.OrgID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Role != orgs.RoleAdmin {
+		t.Fatalf("update not persisted")
+	}
+}
+
+func TestDeleteMembership(t *testing.T) {
+	routes.MembershipStore = orgs.NewMembershipStore()
+	m := orgs.Membership{UserID: "u1", OrgID: "o1", Role: orgs.RoleMember}
+	if err := routes.MembershipStore.Create(m); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := routes.MembershipStore.Delete(m.UserID, m.OrgID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := routes.MembershipStore.Get(m.UserID, m.OrgID); err != orgs.ErrMembershipNotFound {
+		t.Fatalf("membership not removed")
+	}
+}


### PR DESCRIPTION
## Summary
- add OrgStore and MembershipStore variables to routes for injecting fresh instances
- test Organization store CRUD
- test Membership store CRUD

## Testing
- `go test ./... -race`

------
https://chatgpt.com/codex/tasks/task_b_68572dc49910832abca7822d3b4656a3