### PR TITLE
Extend user creation with org support

### DIFF
--- a/routes/users.go
+++ b/routes/users.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/farovictor/bifrost/pkg/logging"
+	"github.com/farovictor/bifrost/pkg/orgs"
 	"github.com/farovictor/bifrost/pkg/users"
 )
 
@@ -16,7 +17,10 @@ var UserStore = users.NewStore()
 // CreateUser handles POST /users and generates an API key.
 func CreateUser(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ID string `json:"id"`
+		ID      string `json:"id"`
+		OrgID   string `json:"org_id"`
+		OrgName string `json:"org_name"`
+		Role    string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request", http.StatusBadRequest)
@@ -26,6 +30,16 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
+
+	role := req.Role
+	if role == "" {
+		role = orgs.RoleMember
+	}
+	if !orgs.ValidateRole(role) {
+		http.Error(w, "invalid role", http.StatusBadRequest)
+		return
+	}
+
 	u := users.User{ID: req.ID, APIKey: generateKey()}
 	if err := UserStore.Create(u); err != nil {
 		switch err {
@@ -36,10 +50,44 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+
+	var orgID string
+	if req.OrgName != "" && req.OrgID == "" {
+		o := orgs.Organization{ID: generateKey(), Name: req.OrgName}
+		if err := OrgStore.Create(o); err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		orgID = o.ID
+	} else if req.OrgID != "" {
+		if _, err := OrgStore.Get(req.OrgID); err != nil {
+			if err == orgs.ErrOrgNotFound {
+				http.Error(w, "organization not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		orgID = req.OrgID
+	}
+
+	if orgID != "" {
+		m := orgs.Membership{UserID: u.ID, OrgID: orgID, Role: role}
+		if err := MembershipStore.Create(m); err != nil {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	resp := struct {
+		users.User
+		Token string `json:"token"`
+	}{User: u, Token: generateKey()}
+
 	logging.Logger.Info().Str("user_id", u.ID).Msg("created user")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(u)
+	json.NewEncoder(w).Encode(resp)
 }
 
 func generateKey() string {


### PR DESCRIPTION
## Summary
- create organization and membership when org fields are supplied on `/v1/users`
- validate role and return a token in the response

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6857314d5250832a9a7fd7d0cb8ea03d