### PR TITLE
Add auth token signing

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// AuthToken represents an authentication token for API users.
+type AuthToken struct {
+	UserID    string    `json:"user_id"`
+	OrgID     string    `json:"org_id,omitempty"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+var signingKey = generateKey()
+
+// generateKey creates a new random signing key.
+func generateKey() []byte {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return nil
+	}
+	return b
+}
+
+// Sign encodes and signs the token using HMAC-SHA256.
+func Sign(t AuthToken) (string, error) {
+	payload, err := json.Marshal(t)
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, signingKey)
+	mac.Write(payload)
+	sig := mac.Sum(nil)
+	return base64.StdEncoding.EncodeToString(payload) + "." +
+		base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// Verify checks the token signature and expiration.
+func Verify(raw string) (AuthToken, error) {
+	parts := strings.Split(raw, ".")
+	if len(parts) != 2 {
+		return AuthToken{}, ErrInvalidToken
+	}
+	payload, err := base64.StdEncoding.DecodeString(parts[0])
+	if err != nil {
+		return AuthToken{}, ErrInvalidToken
+	}
+	sig, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return AuthToken{}, ErrInvalidToken
+	}
+	mac := hmac.New(sha256.New, signingKey)
+	mac.Write(payload)
+	if !hmac.Equal(sig, mac.Sum(nil)) {
+		return AuthToken{}, ErrInvalidToken
+	}
+	var t AuthToken
+	if err := json.Unmarshal(payload, &t); err != nil {
+		return AuthToken{}, ErrInvalidToken
+	}
+	if time.Now().After(t.ExpiresAt) {
+		return AuthToken{}, ErrExpiredToken
+	}
+	return t, nil
+}
+
+var (
+	ErrInvalidToken = errors.New("invalid token")
+	ErrExpiredToken = errors.New("token expired")
+)


### PR DESCRIPTION
## Summary
- add in-memory signing for authentication tokens
- sign and verify tokens using HMAC-SHA256

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68573ebc0194832ab2cab11a4dd13e54