### PR TITLE
Add organization context middleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ func main() {
 	r.Route("/v1", func(r chi.Router) {
 		r.Use(apiVersionCtx("v1"))
 		r.Use(rl.AuthMiddleware())
+		r.Use(rl.OrgCtxMiddleware())
 		r.Get("/hello", v1.SayHello)
 
 		r.Post("/users", routes.CreateUser)

--- a/middlewares/orgctx.go
+++ b/middlewares/orgctx.go
@@ -1,0 +1,57 @@
+package middlewares
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/farovictor/bifrost/pkg/auth"
+	routes "github.com/farovictor/bifrost/routes"
+)
+
+// orgCtxKey is the context key for organization context.
+type orgCtxKey struct{}
+
+// OrgContext holds authentication context about the requester.
+type OrgContext struct {
+	UserID string
+	OrgID  string
+	Role   string
+}
+
+// OrgFromContext extracts organization context from ctx.
+func OrgFromContext(ctx context.Context) OrgContext {
+	v, _ := ctx.Value(orgCtxKey{}).(OrgContext)
+	return v
+}
+
+// OrgCtxMiddleware validates the auth token and stores membership info in context.
+func OrgCtxMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			if !strings.HasPrefix(authHeader, "Bearer ") {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			raw := strings.TrimPrefix(authHeader, "Bearer ")
+			tok, err := auth.Verify(raw)
+			if err != nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			role := ""
+			if m, err := routes.MembershipStore.Get(tok.UserID, tok.OrgID); err == nil {
+				role = m.Role
+			}
+
+			ctx := context.WithValue(r.Context(), orgCtxKey{}, OrgContext{
+				UserID: tok.UserID,
+				OrgID:  tok.OrgID,
+				Role:   role,
+			})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -37,6 +37,7 @@ func TestCreateKey(t *testing.T) {
 	body, _ := json.Marshal(k)
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -67,6 +68,7 @@ func TestDeleteKey(t *testing.T) {
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodDelete, "/v1/keys/"+k.ID, nil)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -99,6 +101,7 @@ func TestCreateKeyExampleJSON(t *testing.T) {
 	payload := `{"id":"jsonex","scope":"read","target":"svc","expires_at":"2050-01-02T15:04:05Z","rate_limit":1}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", strings.NewReader(payload))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 

--- a/tests/proxy_errors_test.go
+++ b/tests/proxy_errors_test.go
@@ -26,6 +26,7 @@ func TestProxyMissingKey(t *testing.T) {
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodGet, "/v1/proxy/backend", nil)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -49,6 +50,7 @@ func TestProxyInvalidKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v1/proxy/backend", nil)
 	req.Header.Set("X-Virtual-Key", "bad")
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -77,6 +79,7 @@ func TestProxyExpiredKey(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/v1/proxy/backend", nil)
 	req.Header.Set("X-Virtual-Key", k.ID)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -120,6 +123,7 @@ func TestProxyScopeViolation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/v1/proxy/backend", nil)
 	req.Header.Set("X-Virtual-Key", k.ID)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -76,6 +76,7 @@ func TestProxy(t *testing.T) {
 				req.Header.Set("X-Virtual-Key", k.ID)
 			}
 			req.Header.Set("X-API-Key", u.APIKey)
+			req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 			rr := httptest.NewRecorder()
 			router.ServeHTTP(rr, req)
 
@@ -135,6 +136,7 @@ func TestProxyScopeEnforcement(t *testing.T) {
 			req := httptest.NewRequest(tc.method, "/v1/proxy/backend", nil)
 			req.Header.Set("X-Virtual-Key", k.ID)
 			req.Header.Set("X-API-Key", u.APIKey)
+			req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 			rr := httptest.NewRecorder()
 			router.ServeHTTP(rr, req)
 

--- a/tests/rate_limit_test.go
+++ b/tests/rate_limit_test.go
@@ -21,6 +21,7 @@ func setupRouterRL() http.Handler {
 	r := chi.NewRouter()
 	r.Route("/v1", func(r chi.Router) {
 		r.Use(rl.AuthMiddleware())
+		r.Use(rl.OrgCtxMiddleware())
 		r.With(rl.RateLimitMiddleware()).Handle("/proxy/{rest:.*}", http.HandlerFunc(v1.Proxy))
 	})
 	return r
@@ -57,6 +58,7 @@ func TestRateLimitExceeded(t *testing.T) {
 	req1 := httptest.NewRequest(http.MethodGet, "/v1/proxy/test", nil)
 	req1.Header.Set("X-Virtual-Key", k.ID)
 	req1.Header.Set("X-API-Key", u.APIKey)
+	req1.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr1 := httptest.NewRecorder()
 	router.ServeHTTP(rr1, req1)
 	if rr1.Code != http.StatusOK {
@@ -66,6 +68,7 @@ func TestRateLimitExceeded(t *testing.T) {
 	req2 := httptest.NewRequest(http.MethodGet, "/v1/proxy/test", nil)
 	req2.Header.Set("X-Virtual-Key", k.ID)
 	req2.Header.Set("X-API-Key", u.APIKey)
+	req2.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr2 := httptest.NewRecorder()
 	router.ServeHTTP(rr2, req2)
 	if rr2.Code != http.StatusTooManyRequests {

--- a/tests/rootkeys_test.go
+++ b/tests/rootkeys_test.go
@@ -23,6 +23,7 @@ func TestCreateRootKey(t *testing.T) {
 	body, _ := json.Marshal(rk)
 	req := httptest.NewRequest(http.MethodPost, "/v1/rootkeys", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -51,6 +52,7 @@ func TestDeleteRootKey(t *testing.T) {
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodDelete, "/v1/rootkeys/"+rk.ID, nil)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -77,6 +79,7 @@ func TestUpdateRootKey(t *testing.T) {
 	body, _ := json.Marshal(updated)
 	req := httptest.NewRequest(http.MethodPut, "/v1/rootkeys/"+orig.ID, bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 

--- a/tests/routes_errors_test.go
+++ b/tests/routes_errors_test.go
@@ -25,6 +25,7 @@ func TestCreateKeyInvalidJSON(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", strings.NewReader("{bad"))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -56,6 +57,7 @@ func TestCreateKeyDuplicate(t *testing.T) {
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -77,6 +79,7 @@ func TestDeleteKeyNotFound(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodDelete, "/v1/keys/unknown", nil)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -101,6 +104,7 @@ func TestCreateKeyMissingService(t *testing.T) {
 	body, _ := json.Marshal(k)
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -138,6 +142,7 @@ func TestCreateKeyInvalidScope(t *testing.T) {
 	body, _ := json.Marshal(k)
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -170,6 +175,7 @@ func TestCreateKeyEmptyScope(t *testing.T) {
 	body, _ := json.Marshal(k)
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -202,6 +208,7 @@ func TestCreateKeyPastExpiration(t *testing.T) {
 	body, _ := json.Marshal(k)
 	req := httptest.NewRequest(http.MethodPost, "/v1/keys", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -20,6 +20,7 @@ func setupRouter() http.Handler {
 	r.Get("/version", routes.Version)
 	r.Route("/v1", func(r chi.Router) {
 		r.Use(rl.AuthMiddleware())
+		r.Use(rl.OrgCtxMiddleware())
 		r.Get("/hello", v1.SayHello)
 		r.Post("/users", routes.CreateUser)
 		r.Post("/keys", routes.CreateKey)
@@ -76,6 +77,7 @@ func TestV1Hello(t *testing.T) {
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodGet, "/v1/hello", nil)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -29,6 +29,7 @@ func TestCreateService(t *testing.T) {
 	body, _ := json.Marshal(svc)
 	req := httptest.NewRequest(http.MethodPost, "/v1/services", bytes.NewReader(body))
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -62,6 +63,7 @@ func TestDeleteService(t *testing.T) {
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodDelete, "/v1/services/"+svc.ID, nil)
 	req.Header.Set("X-API-Key", u.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(u.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 

--- a/tests/testutil.go
+++ b/tests/testutil.go
@@ -1,0 +1,17 @@
+package tests
+
+import (
+	"time"
+
+	"github.com/farovictor/bifrost/pkg/auth"
+)
+
+// makeToken generates a short-lived auth token for a user.
+func makeToken(userID string) string {
+	t := auth.AuthToken{
+		UserID:    userID,
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	tok, _ := auth.Sign(t)
+	return tok
+}

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -27,6 +27,7 @@ func TestCreateUserReturnsToken(t *testing.T) {
 	payload := `{"id":"new"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/users", strings.NewReader(payload))
 	req.Header.Set("X-API-Key", admin.APIKey)
+	req.Header.Set("Authorization", "Bearer "+makeToken(admin.ID))
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 


### PR DESCRIPTION
## Summary
- add `OrgCtxMiddleware` that verifies auth tokens and places org data in request context
- enable `OrgCtxMiddleware` in main router
- update integration test router helpers and requests with tokens

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6857413077d4832a84d65248dedbf546