### PR TITLE
Add agent instructions and folder READMEs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Contributor Guidelines for Agents
+
+Automated agents working in this repository must run the following
+checks before committing:
+
+```bash
+go fmt ./...
+go test ./...
+```
+
+Only commit if both commands succeed.
+
+Commit messages should be concise and written in the present tense.
+Pull request descriptions must summarize the changes and mention test
+results.
+
+For local development you can use the provided Makefile:
+
+```bash
+make setup
+make run
+```

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,13 @@
+# Command Line Interface
+
+The `bifrost` CLI in this directory interacts with the running HTTP API.
+Common commands include:
+
+- `issue` – create a virtual key
+- `revoke` – revoke a virtual key
+- `service-add` and `service-delete` – manage upstream services
+- `rootkey-add`, `rootkey-update`, `rootkey-delete` – manage root keys
+- `user-add` – create an API user
+
+All commands talk to `http://localhost:3333` by default. Use `--addr` to
+override the API address.

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,13 @@
+# Configuration Helpers
+
+This package exposes helper functions that read configuration from
+environment variables. Key variables include:
+
+- `BIFROST_PORT` – HTTP port (default `3333`)
+- `REDIS_ADDR` – Redis address (default `localhost:6379`)
+- `REDIS_PASSWORD` – optional Redis password
+- `REDIS_DB` – Redis DB index (default `0`)
+- `REDIS_PROTOCOL` – Redis protocol version (default `3`)
+- `BIFROST_ENABLE_METRICS` – enable Prometheus metrics when set
+
+See the project `README.md` for more details and examples.

--- a/middlewares/README.md
+++ b/middlewares/README.md
@@ -1,0 +1,10 @@
+# HTTP Middleware
+
+This directory provides reusable middleware used by the router:
+
+- `AuthMiddleware` – checks the `X-API-Key` or `Authorization` header
+- `LoggingMiddleware` – logs method, path, status and duration
+- `MetricsMiddleware` – records Prometheus metrics when enabled
+- `OrgCtxMiddleware` – verifies bearer tokens and stores organization context
+- `RateLimitMiddleware` – limits requests per virtual key using Redis with a
+  local fallback

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,0 +1,13 @@
+# Package Overview
+
+The `pkg` directory contains reusable libraries and in-memory stores:
+
+- `auth` – sign and verify API tokens
+- `keys` – virtual key models and store
+- `rootkeys` – root key models and store
+- `services` – registered service models and store
+- `users` – API user models and store
+- `orgs` – organizations and memberships
+- `logging` – zero log helpers
+- `metrics` – Prometheus metric collectors
+- `version` – application version information

--- a/routes/README.md
+++ b/routes/README.md
@@ -1,0 +1,6 @@
+# HTTP Routes
+
+These packages implement handlers for the `/v1` API. They expose CRUD
+operations for keys, services, users and other resources. The `v1/`
+subdirectory contains version-specific logic such as the proxy and
+redirect handlers.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with contributor instructions
- document the CLI in `cmd/README.md`
- describe configuration helpers in `config/README.md`
- explain the available middleware in `middlewares/README.md`
- outline subpackages in `pkg/README.md`
- summarize the HTTP routes in `routes/README.md`

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685744a14218832aa0e9afea81018557