### PR TITLE
Add helper for Postgres DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Bifrost can be configured through the following environment variables:
 | `REDIS_PASSWORD` | password for Redis, if required | *(empty)* |
 | `REDIS_DB` | numeric Redis DB index to use | `0` |
 | `REDIS_PROTOCOL` | Redis protocol version | `3` |
+| `POSTGRES_DSN` | connection string for PostgreSQL | *(empty)* |
 | `BIFROST_LOG_LEVEL` | log level (`debug`, `info`, `warn`, `error`) | `info` |
 | `BIFROST_LOG_FORMAT` | log output format (`json` or `console`) | `json` |
 | `BIFROST_ENABLE_METRICS` | expose Prometheus metrics | `false` |

--- a/config/README.md
+++ b/config/README.md
@@ -8,6 +8,7 @@ environment variables. Key variables include:
 - `REDIS_PASSWORD` – optional Redis password
 - `REDIS_DB` – Redis DB index (default `0`)
 - `REDIS_PROTOCOL` – Redis protocol version (default `3`)
+- `POSTGRES_DSN` – Postgres connection string
 - `BIFROST_ENABLE_METRICS` – enable Prometheus metrics when set
 
 See the project `README.md` for more details and examples.

--- a/config/config.go
+++ b/config/config.go
@@ -64,3 +64,9 @@ func MetricsEnabled() bool {
 		return false
 	}
 }
+
+// PostgresDSN returns the DSN string for connecting to Postgres.
+// It reads the POSTGRES_DSN environment variable and may be empty if unset.
+func PostgresDSN() string {
+	return os.Getenv("POSTGRES_DSN")
+}


### PR DESCRIPTION
## Summary
- add `PostgresDSN()` helper
- document Postgres DSN in configuration docs
- list `POSTGRES_DSN` in environment variables table

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68574b33e728832a811d492657c6e0bd