### PR TITLE
Implement storage interfaces with Memory and Postgres backends

### DIFF
--- a/pkg/keys/store.go
+++ b/pkg/keys/store.go
@@ -1,23 +1,43 @@
 package keys
 
 import (
+	"database/sql"
 	"errors"
 	"sync"
 )
 
-// Store is an in-memory repository for VirtualKey objects.
-type Store struct {
+// Store defines persistence behavior for VirtualKey objects.
+type Store interface {
+	Create(VirtualKey) error
+	Get(id string) (VirtualKey, error)
+	Update(id string, k VirtualKey) error
+	Delete(id string) error
+	List() []VirtualKey
+}
+
+// MemoryStore is an in-memory repository for VirtualKey objects.
+type MemoryStore struct {
 	mu   sync.RWMutex
 	keys map[string]VirtualKey
 }
 
-// NewStore creates an initialized Store.
-func NewStore() *Store {
-	return &Store{keys: make(map[string]VirtualKey)}
+// NewMemoryStore creates an initialized MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{keys: make(map[string]VirtualKey)}
+}
+
+// NewPostgresStore creates a Postgres-backed store.
+func NewPostgresStore(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// PostgresStore persists VirtualKeys in PostgreSQL.
+type PostgresStore struct {
+	db *sql.DB
 }
 
 // Create inserts a new VirtualKey. Returns an error if the key ID already exists.
-func (s *Store) Create(k VirtualKey) error {
+func (s *MemoryStore) Create(k VirtualKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.keys[k.ID]; ok {
@@ -28,7 +48,7 @@ func (s *Store) Create(k VirtualKey) error {
 }
 
 // Get retrieves a VirtualKey by its ID.
-func (s *Store) Get(id string) (VirtualKey, error) {
+func (s *MemoryStore) Get(id string) (VirtualKey, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	v, ok := s.keys[id]
@@ -39,7 +59,7 @@ func (s *Store) Get(id string) (VirtualKey, error) {
 }
 
 // Update replaces the VirtualKey stored under the given ID.
-func (s *Store) Update(id string, k VirtualKey) error {
+func (s *MemoryStore) Update(id string, k VirtualKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.keys[id]; !ok {
@@ -50,7 +70,7 @@ func (s *Store) Update(id string, k VirtualKey) error {
 }
 
 // Delete removes a VirtualKey from the store.
-func (s *Store) Delete(id string) error {
+func (s *MemoryStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.keys[id]; !ok {
@@ -61,11 +81,81 @@ func (s *Store) Delete(id string) error {
 }
 
 // List returns all VirtualKeys currently in the store.
-func (s *Store) List() []VirtualKey {
+func (s *MemoryStore) List() []VirtualKey {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]VirtualKey, 0, len(s.keys))
 	for _, v := range s.keys {
+		out = append(out, v)
+	}
+	return out
+}
+
+// Create inserts a virtual key into the database.
+func (s *PostgresStore) Create(k VirtualKey) error {
+	_, err := s.db.Exec("INSERT INTO virtual_keys (id, scope, expires_at, target, rate_limit) VALUES ($1,$2,$3,$4,$5)",
+		k.ID, k.Scope, k.ExpiresAt, k.Target, k.RateLimit)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrKeyExists
+		}
+	}
+	return err
+}
+
+// Get retrieves a virtual key by ID.
+func (s *PostgresStore) Get(id string) (VirtualKey, error) {
+	var v VirtualKey
+	row := s.db.QueryRow("SELECT id, scope, expires_at, target, rate_limit FROM virtual_keys WHERE id=$1", id)
+	if err := row.Scan(&v.ID, &v.Scope, &v.ExpiresAt, &v.Target, &v.RateLimit); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return VirtualKey{}, ErrKeyNotFound
+		}
+		return VirtualKey{}, err
+	}
+	return v, nil
+}
+
+// Update replaces an existing virtual key.
+func (s *PostgresStore) Update(id string, k VirtualKey) error {
+	res, err := s.db.Exec("UPDATE virtual_keys SET scope=$1, expires_at=$2, target=$3, rate_limit=$4 WHERE id=$5",
+		k.Scope, k.ExpiresAt, k.Target, k.RateLimit, id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrKeyNotFound
+	}
+	return nil
+}
+
+// Delete removes a virtual key by ID.
+func (s *PostgresStore) Delete(id string) error {
+	res, err := s.db.Exec("DELETE FROM virtual_keys WHERE id=$1", id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrKeyNotFound
+	}
+	return nil
+}
+
+// List returns all virtual keys from the database.
+func (s *PostgresStore) List() []VirtualKey {
+	rows, err := s.db.Query("SELECT id, scope, expires_at, target, rate_limit FROM virtual_keys")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []VirtualKey
+	for rows.Next() {
+		var v VirtualKey
+		if err := rows.Scan(&v.ID, &v.Scope, &v.ExpiresAt, &v.Target, &v.RateLimit); err != nil {
+			continue
+		}
 		out = append(out, v)
 	}
 	return out

--- a/pkg/orgs/store.go
+++ b/pkg/orgs/store.go
@@ -1,23 +1,43 @@
 package orgs
 
 import (
+	"database/sql"
 	"errors"
 	"sync"
 )
 
-// Store keeps Organizations in memory with concurrency safety.
-type Store struct {
+// Store defines persistence behavior for Organization objects.
+type Store interface {
+	Create(Organization) error
+	Get(id string) (Organization, error)
+	Delete(id string) error
+	Update(Organization) error
+	List() []Organization
+}
+
+// MemoryStore keeps Organizations in memory with concurrency safety.
+type MemoryStore struct {
 	mu   sync.RWMutex
 	orgs map[string]Organization
 }
 
-// NewStore creates an initialized Store.
-func NewStore() *Store {
-	return &Store{orgs: make(map[string]Organization)}
+// NewMemoryStore creates an initialized MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{orgs: make(map[string]Organization)}
+}
+
+// NewPostgresStore creates a Postgres-backed store.
+func NewPostgresStore(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// PostgresStore persists organizations in PostgreSQL.
+type PostgresStore struct {
+	db *sql.DB
 }
 
 // Create inserts a new Organization. Returns error if ID already exists.
-func (s *Store) Create(o Organization) error {
+func (s *MemoryStore) Create(o Organization) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.orgs[o.ID]; ok {
@@ -28,7 +48,7 @@ func (s *Store) Create(o Organization) error {
 }
 
 // Get retrieves an Organization by ID.
-func (s *Store) Get(id string) (Organization, error) {
+func (s *MemoryStore) Get(id string) (Organization, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	o, ok := s.orgs[id]
@@ -39,7 +59,7 @@ func (s *Store) Get(id string) (Organization, error) {
 }
 
 // Delete removes an Organization from the store.
-func (s *Store) Delete(id string) error {
+func (s *MemoryStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.orgs[id]; !ok {
@@ -50,7 +70,7 @@ func (s *Store) Delete(id string) error {
 }
 
 // Update replaces an existing Organization.
-func (s *Store) Update(o Organization) error {
+func (s *MemoryStore) Update(o Organization) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.orgs[o.ID]; !ok {
@@ -61,11 +81,79 @@ func (s *Store) Update(o Organization) error {
 }
 
 // List returns all Organizations currently in the store.
-func (s *Store) List() []Organization {
+func (s *MemoryStore) List() []Organization {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]Organization, 0, len(s.orgs))
 	for _, o := range s.orgs {
+		out = append(out, o)
+	}
+	return out
+}
+
+// Create inserts an organization into the database.
+func (s *PostgresStore) Create(o Organization) error {
+	_, err := s.db.Exec("INSERT INTO organizations (id, name) VALUES ($1, $2)", o.ID, o.Name)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrOrgExists
+		}
+	}
+	return err
+}
+
+// Get retrieves an organization by ID.
+func (s *PostgresStore) Get(id string) (Organization, error) {
+	var o Organization
+	row := s.db.QueryRow("SELECT id, name FROM organizations WHERE id=$1", id)
+	if err := row.Scan(&o.ID, &o.Name); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return Organization{}, ErrOrgNotFound
+		}
+		return Organization{}, err
+	}
+	return o, nil
+}
+
+// Delete removes an organization.
+func (s *PostgresStore) Delete(id string) error {
+	res, err := s.db.Exec("DELETE FROM organizations WHERE id=$1", id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrOrgNotFound
+	}
+	return nil
+}
+
+// Update replaces an organization.
+func (s *PostgresStore) Update(o Organization) error {
+	res, err := s.db.Exec("UPDATE organizations SET name=$1 WHERE id=$2", o.Name, o.ID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrOrgNotFound
+	}
+	return nil
+}
+
+// List returns all organizations.
+func (s *PostgresStore) List() []Organization {
+	rows, err := s.db.Query("SELECT id, name FROM organizations")
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []Organization
+	for rows.Next() {
+		var o Organization
+		if err := rows.Scan(&o.ID, &o.Name); err != nil {
+			continue
+		}
 		out = append(out, o)
 	}
 	return out

--- a/pkg/rootkeys/store.go
+++ b/pkg/rootkeys/store.go
@@ -1,23 +1,42 @@
 package rootkeys
 
 import (
+	"database/sql"
 	"errors"
 	"sync"
 )
 
-// Store keeps RootKeys in memory with concurrency safety.
-type Store struct {
+// Store defines persistence behavior for RootKey objects.
+type Store interface {
+	Create(RootKey) error
+	Get(id string) (RootKey, error)
+	Delete(id string) error
+	Update(RootKey) error
+}
+
+// MemoryStore keeps RootKeys in memory with concurrency safety.
+type MemoryStore struct {
 	mu   sync.RWMutex
 	keys map[string]RootKey
 }
 
-// NewStore creates an initialized Store.
-func NewStore() *Store {
-	return &Store{keys: make(map[string]RootKey)}
+// NewMemoryStore creates an initialized MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{keys: make(map[string]RootKey)}
+}
+
+// NewPostgresStore creates a Postgres-backed store.
+func NewPostgresStore(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// PostgresStore persists RootKeys in PostgreSQL.
+type PostgresStore struct {
+	db *sql.DB
 }
 
 // Create inserts a new RootKey. Returns error if ID already exists.
-func (s *Store) Create(k RootKey) error {
+func (s *MemoryStore) Create(k RootKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.keys[k.ID]; ok {
@@ -28,7 +47,7 @@ func (s *Store) Create(k RootKey) error {
 }
 
 // Get retrieves a RootKey by ID.
-func (s *Store) Get(id string) (RootKey, error) {
+func (s *MemoryStore) Get(id string) (RootKey, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	k, ok := s.keys[id]
@@ -39,7 +58,7 @@ func (s *Store) Get(id string) (RootKey, error) {
 }
 
 // Delete removes a RootKey from the store.
-func (s *Store) Delete(id string) error {
+func (s *MemoryStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.keys[id]; !ok {
@@ -50,13 +69,63 @@ func (s *Store) Delete(id string) error {
 }
 
 // Update replaces an existing RootKey.
-func (s *Store) Update(k RootKey) error {
+func (s *MemoryStore) Update(k RootKey) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.keys[k.ID]; !ok {
 		return ErrKeyNotFound
 	}
 	s.keys[k.ID] = k
+	return nil
+}
+
+// Create inserts a root key into the database.
+func (s *PostgresStore) Create(k RootKey) error {
+	_, err := s.db.Exec("INSERT INTO root_keys (id, api_key) VALUES ($1,$2)", k.ID, k.APIKey)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrKeyExists
+		}
+	}
+	return err
+}
+
+// Get retrieves a root key by ID.
+func (s *PostgresStore) Get(id string) (RootKey, error) {
+	var k RootKey
+	row := s.db.QueryRow("SELECT id, api_key FROM root_keys WHERE id=$1", id)
+	if err := row.Scan(&k.ID, &k.APIKey); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return RootKey{}, ErrKeyNotFound
+		}
+		return RootKey{}, err
+	}
+	return k, nil
+}
+
+// Delete removes a root key.
+func (s *PostgresStore) Delete(id string) error {
+	res, err := s.db.Exec("DELETE FROM root_keys WHERE id=$1", id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrKeyNotFound
+	}
+	return nil
+}
+
+// Update replaces a root key.
+func (s *PostgresStore) Update(k RootKey) error {
+	res, err := s.db.Exec("UPDATE root_keys SET api_key=$1 WHERE id=$2", k.APIKey, k.ID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrKeyNotFound
+	}
 	return nil
 }
 

--- a/pkg/users/store.go
+++ b/pkg/users/store.go
@@ -1,24 +1,44 @@
 package users
 
 import (
+	"database/sql"
 	"errors"
 	"sync"
 )
 
-// Store holds users in memory with concurrency safety.
-type Store struct {
+// Store defines the persistence behavior for User objects.
+type Store interface {
+	Create(User) error
+	Get(id string) (User, error)
+	GetByAPIKey(key string) (User, error)
+	Delete(id string) error
+	Update(User) error
+}
+
+// MemoryStore holds users in memory with concurrency safety.
+type MemoryStore struct {
 	mu    sync.RWMutex
 	users map[string]User
 	byKey map[string]User
 }
 
-// NewStore creates an initialized Store.
-func NewStore() *Store {
-	return &Store{users: make(map[string]User), byKey: make(map[string]User)}
+// NewMemoryStore creates an initialized MemoryStore.
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{users: make(map[string]User), byKey: make(map[string]User)}
+}
+
+// NewPostgresStore creates a Postgres-backed store.
+func NewPostgresStore(db *sql.DB) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// PostgresStore persists users in a PostgreSQL database.
+type PostgresStore struct {
+	db *sql.DB
 }
 
 // Create inserts a new User. Returns error if ID already exists.
-func (s *Store) Create(u User) error {
+func (s *MemoryStore) Create(u User) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.users[u.ID]; ok {
@@ -30,7 +50,7 @@ func (s *Store) Create(u User) error {
 }
 
 // Get retrieves a User by ID.
-func (s *Store) Get(id string) (User, error) {
+func (s *MemoryStore) Get(id string) (User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	u, ok := s.users[id]
@@ -41,7 +61,7 @@ func (s *Store) Get(id string) (User, error) {
 }
 
 // GetByAPIKey retrieves a User by its API key.
-func (s *Store) GetByAPIKey(key string) (User, error) {
+func (s *MemoryStore) GetByAPIKey(key string) (User, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	u, ok := s.byKey[key]
@@ -52,7 +72,7 @@ func (s *Store) GetByAPIKey(key string) (User, error) {
 }
 
 // Delete removes a User.
-func (s *Store) Delete(id string) error {
+func (s *MemoryStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	u, ok := s.users[id]
@@ -65,7 +85,7 @@ func (s *Store) Delete(id string) error {
 }
 
 // Update replaces an existing user.
-func (s *Store) Update(u User) error {
+func (s *MemoryStore) Update(u User) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if _, ok := s.users[u.ID]; !ok {
@@ -75,6 +95,69 @@ func (s *Store) Update(u User) error {
 	delete(s.byKey, old.APIKey)
 	s.users[u.ID] = u
 	s.byKey[u.APIKey] = u
+	return nil
+}
+
+// Create inserts a new user into the database.
+func (s *PostgresStore) Create(u User) error {
+	_, err := s.db.Exec("INSERT INTO users (id, api_key) VALUES ($1, $2)", u.ID, u.APIKey)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrUserExists
+		}
+	}
+	return err
+}
+
+// Get retrieves a user by ID.
+func (s *PostgresStore) Get(id string) (User, error) {
+	var u User
+	row := s.db.QueryRow("SELECT id, api_key FROM users WHERE id=$1", id)
+	if err := row.Scan(&u.ID, &u.APIKey); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, err
+	}
+	return u, nil
+}
+
+// GetByAPIKey retrieves a user by API key.
+func (s *PostgresStore) GetByAPIKey(key string) (User, error) {
+	var u User
+	row := s.db.QueryRow("SELECT id, api_key FROM users WHERE api_key=$1", key)
+	if err := row.Scan(&u.ID, &u.APIKey); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return User{}, ErrUserNotFound
+		}
+		return User{}, err
+	}
+	return u, nil
+}
+
+// Delete removes a user by ID.
+func (s *PostgresStore) Delete(id string) error {
+	res, err := s.db.Exec("DELETE FROM users WHERE id=$1", id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrUserNotFound
+	}
+	return nil
+}
+
+// Update modifies an existing user.
+func (s *PostgresStore) Update(u User) error {
+	res, err := s.db.Exec("UPDATE users SET api_key=$1 WHERE id=$2", u.APIKey, u.ID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrUserNotFound
+	}
 	return nil
 }
 

--- a/routes/keys.go
+++ b/routes/keys.go
@@ -13,7 +13,7 @@ import (
 )
 
 // KeyStore holds the active VirtualKeys in memory.
-var KeyStore = keys.NewStore()
+var KeyStore = keys.NewMemoryStore()
 
 // CreateKey handles POST /keys and stores a new VirtualKey.
 func CreateKey(w http.ResponseWriter, r *http.Request) {

--- a/routes/orgs.go
+++ b/routes/orgs.go
@@ -3,7 +3,7 @@ package routes
 import "github.com/farovictor/bifrost/pkg/orgs"
 
 // OrgStore holds defined organizations in memory.
-var OrgStore = orgs.NewStore()
+var OrgStore = orgs.NewMemoryStore()
 
 // MembershipStore holds organization memberships in memory.
 var MembershipStore = orgs.NewMembershipStore()

--- a/routes/rootkeys.go
+++ b/routes/rootkeys.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RootKeyStore holds active root keys in memory.
-var RootKeyStore = rootkeys.NewStore()
+var RootKeyStore = rootkeys.NewMemoryStore()
 
 // CreateRootKey handles POST /rootkeys to store a new root key.
 func CreateRootKey(w http.ResponseWriter, r *http.Request) {

--- a/routes/services.go
+++ b/routes/services.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ServiceStore holds defined services in memory.
-var ServiceStore = services.NewStore()
+var ServiceStore = services.NewMemoryStore()
 
 // CreateService handles POST /services to store a new Service.
 func CreateService(w http.ResponseWriter, r *http.Request) {

--- a/routes/users.go
+++ b/routes/users.go
@@ -14,7 +14,7 @@ import (
 )
 
 // UserStore holds registered users in memory.
-var UserStore = users.NewStore()
+var UserStore = users.NewMemoryStore()
 
 // CreateUser handles POST /users and generates an API key.
 func CreateUser(w http.ResponseWriter, r *http.Request) {

--- a/tests/auth_org_context_test.go
+++ b/tests/auth_org_context_test.go
@@ -54,8 +54,8 @@ func TestUserCreationOrgContext(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			routes.UserStore = users.NewStore()
-			routes.OrgStore = orgs.NewStore()
+			routes.UserStore = users.NewMemoryStore()
+			routes.OrgStore = orgs.NewMemoryStore()
 			routes.MembershipStore = orgs.NewMembershipStore()
 
 			admin := users.User{ID: "admin", APIKey: "admink"}
@@ -173,8 +173,8 @@ func TestOrgCtxMiddlewareFailures(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			routes.UserStore = users.NewStore()
-			routes.OrgStore = orgs.NewStore()
+			routes.UserStore = users.NewMemoryStore()
+			routes.OrgStore = orgs.NewMemoryStore()
 			routes.MembershipStore = orgs.NewMembershipStore()
 			routes.UserStore.Create(u)
 			routes.OrgStore.Create(o)

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -17,10 +17,10 @@ import (
 )
 
 func TestCreateKey(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.ServiceStore = services.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk", APIKey: "k"}
@@ -56,8 +56,8 @@ func TestCreateKey(t *testing.T) {
 }
 
 func TestDeleteKey(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	k := keys.VirtualKey{ID: "dead", Scope: "x", Target: "svc", ExpiresAt: time.Now(), RateLimit: 1}
@@ -82,10 +82,10 @@ func TestDeleteKey(t *testing.T) {
 }
 
 func TestCreateKeyExampleJSON(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.ServiceStore = services.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk2", APIKey: "k"}

--- a/tests/orgs_test.go
+++ b/tests/orgs_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreateGetOrg(t *testing.T) {
-	routes.OrgStore = orgs.NewStore()
+	routes.OrgStore = orgs.NewMemoryStore()
 	o := orgs.Organization{ID: "org1", Name: "Test Org"}
 	if err := routes.OrgStore.Create(o); err != nil {
 		t.Fatalf("create: %v", err)
@@ -23,7 +23,7 @@ func TestCreateGetOrg(t *testing.T) {
 }
 
 func TestUpdateOrg(t *testing.T) {
-	routes.OrgStore = orgs.NewStore()
+	routes.OrgStore = orgs.NewMemoryStore()
 	o := orgs.Organization{ID: "org1", Name: "Old"}
 	if err := routes.OrgStore.Create(o); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -42,7 +42,7 @@ func TestUpdateOrg(t *testing.T) {
 }
 
 func TestDeleteOrg(t *testing.T) {
-	routes.OrgStore = orgs.NewStore()
+	routes.OrgStore = orgs.NewMemoryStore()
 	o := orgs.Organization{ID: "org1", Name: "Del"}
 	if err := routes.OrgStore.Create(o); err != nil {
 		t.Fatalf("seed: %v", err)

--- a/tests/proxy_errors_test.go
+++ b/tests/proxy_errors_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 func TestProxyMissingKey(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.KeyStore = keys.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
@@ -39,10 +39,10 @@ func TestProxyMissingKey(t *testing.T) {
 }
 
 func TestProxyInvalidKey(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.KeyStore = keys.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
@@ -63,10 +63,10 @@ func TestProxyInvalidKey(t *testing.T) {
 }
 
 func TestProxyExpiredKey(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.KeyStore = keys.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
@@ -92,10 +92,10 @@ func TestProxyExpiredKey(t *testing.T) {
 }
 
 func TestProxyScopeViolation(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.KeyStore = keys.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -27,10 +27,10 @@ func TestProxy(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			routes.ServiceStore = services.NewStore()
-			routes.KeyStore = keys.NewStore()
-			routes.RootKeyStore = rootkeys.NewStore()
-			routes.UserStore = users.NewStore()
+			routes.ServiceStore = services.NewMemoryStore()
+			routes.KeyStore = keys.NewMemoryStore()
+			routes.RootKeyStore = rootkeys.NewMemoryStore()
+			routes.UserStore = users.NewMemoryStore()
 			u := users.User{ID: "u", APIKey: "secret"}
 			routes.UserStore.Create(u)
 
@@ -105,10 +105,10 @@ func TestProxyScopeEnforcement(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			routes.ServiceStore = services.NewStore()
-			routes.KeyStore = keys.NewStore()
-			routes.RootKeyStore = rootkeys.NewStore()
-			routes.UserStore = users.NewStore()
+			routes.ServiceStore = services.NewMemoryStore()
+			routes.KeyStore = keys.NewMemoryStore()
+			routes.RootKeyStore = rootkeys.NewMemoryStore()
+			routes.UserStore = users.NewMemoryStore()
 			u := users.User{ID: "u", APIKey: "secret"}
 			routes.UserStore.Create(u)
 

--- a/tests/rate_limit_test.go
+++ b/tests/rate_limit_test.go
@@ -28,10 +28,10 @@ func setupRouterRL() http.Handler {
 }
 
 func TestRateLimitExceeded(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.KeyStore = keys.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 

--- a/tests/rootkeys_test.go
+++ b/tests/rootkeys_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestCreateRootKey(t *testing.T) {
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
@@ -41,8 +41,8 @@ func TestCreateRootKey(t *testing.T) {
 }
 
 func TestDeleteRootKey(t *testing.T) {
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "dead", APIKey: "k"}
@@ -65,8 +65,8 @@ func TestDeleteRootKey(t *testing.T) {
 }
 
 func TestUpdateRootKey(t *testing.T) {
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	orig := rootkeys.RootKey{ID: "rk", APIKey: "old"}

--- a/tests/routes_errors_test.go
+++ b/tests/routes_errors_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func TestCreateKeyInvalidJSON(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
@@ -39,9 +39,9 @@ func TestCreateKeyInvalidJSON(t *testing.T) {
 }
 
 func TestCreateKeyDuplicate(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.ServiceStore = services.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	svc := services.Service{ID: "svc", Endpoint: "http://example.com", RootKeyID: "rk"}
@@ -71,8 +71,8 @@ func TestCreateKeyDuplicate(t *testing.T) {
 }
 
 func TestDeleteKeyNotFound(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
@@ -93,9 +93,9 @@ func TestDeleteKeyNotFound(t *testing.T) {
 }
 
 func TestCreateKeyMissingService(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.ServiceStore = services.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
@@ -122,10 +122,10 @@ func TestCreateKeyMissingService(t *testing.T) {
 }
 
 func TestCreateKeyInvalidScope(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.ServiceStore = services.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk-scope", APIKey: "k"}
@@ -155,10 +155,10 @@ func TestCreateKeyInvalidScope(t *testing.T) {
 }
 
 func TestCreateKeyEmptyScope(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.ServiceStore = services.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk-empty", APIKey: "k"}
@@ -188,10 +188,10 @@ func TestCreateKeyEmptyScope(t *testing.T) {
 }
 
 func TestCreateKeyPastExpiration(t *testing.T) {
-	routes.KeyStore = keys.NewStore()
-	routes.ServiceStore = services.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.KeyStore = keys.NewMemoryStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk-exp", APIKey: "k"}

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -71,7 +71,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestV1Hello(t *testing.T) {
-	routes.UserStore = users.NewStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestCreateService(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk", APIKey: "k"}
@@ -47,9 +47,9 @@ func TestCreateService(t *testing.T) {
 }
 
 func TestDeleteService(t *testing.T) {
-	routes.ServiceStore = services.NewStore()
-	routes.RootKeyStore = rootkeys.NewStore()
-	routes.UserStore = users.NewStore()
+	routes.ServiceStore = services.NewMemoryStore()
+	routes.RootKeyStore = rootkeys.NewMemoryStore()
+	routes.UserStore = users.NewMemoryStore()
 	u := users.User{ID: "u", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rkdead", APIKey: "k"}

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestCreateUserReturnsToken(t *testing.T) {
-	routes.UserStore = users.NewStore()
-	routes.OrgStore = orgs.NewStore()
+	routes.UserStore = users.NewMemoryStore()
+	routes.OrgStore = orgs.NewMemoryStore()
 	routes.MembershipStore = orgs.NewMembershipStore()
 
 	admin := users.User{ID: "admin", APIKey: "secret"}


### PR DESCRIPTION
## Summary
- introduce `Store` interfaces for users, orgs, services, root keys and keys
- rename in-memory structs to `MemoryStore`
- add `PostgresStore` implementations using `database/sql`
- update routes and tests to use `NewMemoryStore`

## Testing
- `go fmt ./...`
- `go test ./...`
- `go test ./tests`

------
https://chatgpt.com/codex/tasks/task_b_68574c334e10832a9855e9aae7b0a469