### PR TITLE
Add migrate command and SQL migrations

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -8,6 +8,7 @@ Common commands include:
 - `service-add` and `service-delete` – manage upstream services
 - `rootkey-add`, `rootkey-update`, `rootkey-delete` – manage root keys
 - `user-add` – create an API user
+- `migrate` – apply SQL migrations in `migrations/`
 
 All commands talk to `http://localhost:3333` by default. Use `--addr` to
 override the API address.

--- a/cmd/bifrost/migrate.go
+++ b/cmd/bifrost/migrate.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/farovictor/bifrost/config"
+	"github.com/spf13/cobra"
+)
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate",
+	Short: "Apply database migrations",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dsn := config.PostgresDSN()
+		if dsn == "" {
+			return fmt.Errorf("POSTGRES_DSN is not set")
+		}
+		db, err := sql.Open("postgres", dsn)
+		if err != nil {
+			return err
+		}
+		defer db.Close()
+		if err := db.Ping(); err != nil {
+			return err
+		}
+		files, err := filepath.Glob(filepath.Join("migrations", "*.sql"))
+		if err != nil {
+			return err
+		}
+		sort.Strings(files)
+		for _, f := range files {
+			b, err := os.ReadFile(f)
+			if err != nil {
+				return err
+			}
+			if _, err := db.Exec(string(b)); err != nil {
+				return fmt.Errorf("%s: %w", f, err)
+			}
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "applied %d migrations\n", len(files))
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(migrateCmd)
+}

--- a/migrations/003_create_users.sql
+++ b/migrations/003_create_users.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS users (
+    id VARCHAR(255) PRIMARY KEY,
+    api_key TEXT NOT NULL
+);

--- a/migrations/004_create_root_keys.sql
+++ b/migrations/004_create_root_keys.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS root_keys (
+    id VARCHAR(255) PRIMARY KEY,
+    api_key TEXT NOT NULL
+);

--- a/migrations/005_create_services.sql
+++ b/migrations/005_create_services.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS services (
+    id VARCHAR(255) PRIMARY KEY,
+    endpoint TEXT NOT NULL,
+    root_key_id VARCHAR(255) NOT NULL REFERENCES root_keys(id)
+);

--- a/migrations/006_create_virtual_keys.sql
+++ b/migrations/006_create_virtual_keys.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS virtual_keys (
+    id VARCHAR(255) PRIMARY KEY,
+    scope VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    target VARCHAR(255) NOT NULL,
+    rate_limit INTEGER NOT NULL
+);


### PR DESCRIPTION
## Summary
- add SQL migrations for users, root keys, services and virtual keys
- implement `migrate` command in CLI
- document the new command

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6857506d3b70832ab36eacb2f518dec2