### PR TITLE
Add PostgreSQL service for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make run
 ## Running with Docker Compose
 
 The repository provides a `docker-compose.yml` that starts Bifrost together with
-Redis. Make sure both **Docker** and **Docker Compose** are installed, then run:
+Redis and PostgreSQL. Make sure both **Docker** and **Docker Compose** are installed, then run:
 
 ```bash
 docker-compose up -d
@@ -37,6 +37,14 @@ go test ./...
 
 See `test-rate-limiting.sh` for a small script that exercises the rate limit
 middleware against the Compose setup.
+
+The Compose file sets `POSTGRES_DSN` for Bifrost to connect to the bundled
+PostgreSQL service. If you run the server manually, configure the variable like
+so:
+
+```bash
+export POSTGRES_DSN="postgres://bifrost:bifrost@localhost:5432/bifrost?sslmode=disable"
+```
 
 ## Example Request
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,10 @@ services:
     environment:
       BIFROST_PORT: "3333"
       REDIS_ADDR: "redis:6379"
+      POSTGRES_DSN: "postgres://bifrost:bifrost@postgres:5432/bifrost?sslmode=disable"
     depends_on:
       - redis
+      - postgres
     networks:
       - internal
 
@@ -22,9 +24,23 @@ services:
     networks:
       - internal
 
+  postgres:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: bifrost
+      POSTGRES_PASSWORD: bifrost
+      POSTGRES_DB: bifrost
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - internal
+
 networks:
   internal:
     driver: bridge
 
 volumes:
   redis-data:
+  postgres-data:


### PR DESCRIPTION
## Summary
- extend docker-compose with a Postgres service and volume
- wire `POSTGRES_DSN` into the `bifrost` service
- document Postgres usage and DSN configuration in README

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68575247e6d0832aa98df495131e0325