### PR TITLE
Add init script for PostgreSQL service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./scripts/init-postgres.sh:/docker-entrypoint-initdb.d/init-postgres.sh:ro
+      - ./migrations:/docker-entrypoint-initdb.d/migrations:ro
     networks:
       - internal
 

--- a/scripts/init-postgres.sh
+++ b/scripts/init-postgres.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Apply migrations if present
+for f in /docker-entrypoint-initdb.d/migrations/*.sql; do
+    [ -f "$f" ] || continue
+    echo "Applying $f"
+    psql --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -f "$f"
+done


### PR DESCRIPTION
## Summary
- run migration scripts automatically when the postgres container starts
- update docker-compose to mount the init script and migrations

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68574a5ab958832ab2a74b9d54036b8e