### PR TITLE
Update Docker Compose defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       - "3333:3333"
     environment:
       BIFROST_PORT: "3333"
-      REDIS_ADDR: "redis:6379"
-      POSTGRES_DSN: "postgres://bifrost:bifrost@postgres:5432/bifrost?sslmode=disable"
+      REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
+      POSTGRES_DSN: ${POSTGRES_DSN:-postgres://bifrost:bifrost@postgres:5432/bifrost?sslmode=disable}
     depends_on:
       redis:
         condition: service_started


### PR DESCRIPTION
## Summary
- allow overriding Redis and Postgres addresses in docker-compose via environment variables

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68575d056af8832a979c5386f7975ce9