### PR TITLE
Add admin org initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Bifrost can be configured through the following environment variables:
 | `BIFROST_ENABLE_METRICS` | expose Prometheus metrics | `false` |
 | `BIFROST_ADMIN_ID` | ID for the initial admin user | `admin` |
 | `BIFROST_ADMIN_API_KEY` | API key for the admin user | random |
+| `BIFROST_ADMIN_ORG_ID` | ID for the admin organization | `admin-org` |
+| `BIFROST_ADMIN_ORG_NAME` | name of the admin organization | `Admin` |
 
 Use these variables to control the verbosity and choose between machine-readable JSON logs or a console-friendly format.
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -9,8 +9,9 @@ Common commands include:
 - `rootkey-add`, `rootkey-update`, `rootkey-delete` – manage root keys
 - `user-add` – create an API user
 - `migrate` – apply SQL migrations in `migrations/`
-- `init-admin` – create an admin user in the database
-  (uses `BIFROST_ADMIN_ID` and `BIFROST_ADMIN_API_KEY` if set)
+- `init-admin` – create an admin user and organization in the database
+  (uses `BIFROST_ADMIN_ID`, `BIFROST_ADMIN_API_KEY`,
+  `BIFROST_ADMIN_ORG_ID`, and `BIFROST_ADMIN_ORG_NAME` if set)
 
 All commands talk to `http://localhost:3333` by default. Use `--addr` to
 override the API address.

--- a/cmd/bifrost/init_admin.go
+++ b/cmd/bifrost/init_admin.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/farovictor/bifrost/config"
 	"github.com/farovictor/bifrost/pkg/database"
+	"github.com/farovictor/bifrost/pkg/orgs"
 	"github.com/farovictor/bifrost/pkg/users"
 	"github.com/spf13/cobra"
 )
 
 var initAdminID string
+var initAdminOrgID string
+var initAdminOrgName string
 
 var initAdminCmd = &cobra.Command{
 	Use:   "init-admin",
@@ -25,6 +28,12 @@ var initAdminCmd = &cobra.Command{
 		}
 		sqlDB, _ := db.DB()
 		defer sqlDB.Close()
+
+		orgStore := orgs.NewPostgresStore(db)
+		o := orgs.Organization{ID: initAdminOrgID, Name: initAdminOrgName}
+		if err := orgStore.Create(o); err != nil && err != orgs.ErrOrgExists {
+			return err
+		}
 
 		store := users.NewPostgresStore(db)
 		key := config.AdminAPIKey()
@@ -45,5 +54,7 @@ var initAdminCmd = &cobra.Command{
 
 func init() {
 	initAdminCmd.Flags().StringVar(&initAdminID, "id", config.AdminID(), "admin user id")
+	initAdminCmd.Flags().StringVar(&initAdminOrgID, "org-id", config.AdminOrgID(), "admin organization id")
+	initAdminCmd.Flags().StringVar(&initAdminOrgName, "org-name", config.AdminOrgName(), "admin organization name")
 	rootCmd.AddCommand(initAdminCmd)
 }

--- a/config/README.md
+++ b/config/README.md
@@ -12,5 +12,7 @@ environment variables. Key variables include:
 - `BIFROST_ENABLE_METRICS` – enable Prometheus metrics when set
 - `BIFROST_ADMIN_ID` – ID for the initial admin user (default `admin`)
 - `BIFROST_ADMIN_API_KEY` – API key for the admin, random when unset
+- `BIFROST_ADMIN_ORG_ID` – ID for the admin organization (default `admin-org`)
+- `BIFROST_ADMIN_ORG_NAME` – name for the admin organization (default `Admin`)
 
 See the project `README.md` for more details and examples.

--- a/config/config.go
+++ b/config/config.go
@@ -86,3 +86,23 @@ func AdminID() string {
 func AdminAPIKey() string {
 	return os.Getenv("BIFROST_ADMIN_API_KEY")
 }
+
+// AdminOrgID returns the ID for the initial admin organization.
+// It reads BIFROST_ADMIN_ORG_ID and defaults to "admin-org" when unset.
+func AdminOrgID() string {
+	id := os.Getenv("BIFROST_ADMIN_ORG_ID")
+	if id == "" {
+		id = "admin-org"
+	}
+	return id
+}
+
+// AdminOrgName returns the name for the initial admin organization.
+// It reads BIFROST_ADMIN_ORG_NAME and defaults to "Admin" when unset.
+func AdminOrgName() string {
+	name := os.Getenv("BIFROST_ADMIN_ORG_NAME")
+	if name == "" {
+		name = "Admin"
+	}
+	return name
+}

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -12,6 +12,7 @@ psql $DATABASE_URL -f migrations/002_create_org_memberships.sql
 Any migration tool that executes SQL scripts in order (like `migrate` or `goose`) will also work.
 
 After the schema is in place run `bifrost init-admin` to create the initial admin
-user. Set `BIFROST_ADMIN_ID` and `BIFROST_ADMIN_API_KEY` to override the defaults.
+user and organization. Set `BIFROST_ADMIN_ID`, `BIFROST_ADMIN_API_KEY`,
+`BIFROST_ADMIN_ORG_ID`, and `BIFROST_ADMIN_ORG_NAME` to override the defaults.
 The command prints the resulting API key so you can store it securely.
 


### PR DESCRIPTION
## Summary
- init-admin command now also creates an admin organization
- support environment variables `BIFROST_ADMIN_ORG_ID` and `BIFROST_ADMIN_ORG_NAME`
- document the new variables and updated usage

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68578672e174832aa327d0a51525d12d