### PR TITLE
Add UUID-based ID and new fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/migrations/001_create_organizations.sql
+++ b/migrations/001_create_organizations.sql
@@ -1,4 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 CREATE TABLE IF NOT EXISTS organizations (
-    id VARCHAR(255) PRIMARY KEY,
-    name TEXT NOT NULL
+    id VARCHAR(255) PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    email TEXT NOT NULL
 );

--- a/migrations/003_create_users.sql
+++ b/migrations/003_create_users.sql
@@ -1,4 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
 CREATE TABLE IF NOT EXISTS users (
-    id VARCHAR(255) PRIMARY KEY,
+    id VARCHAR(255) PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    email TEXT NOT NULL,
     api_key TEXT NOT NULL
 );

--- a/pkg/orgs/id.go
+++ b/pkg/orgs/id.go
@@ -1,0 +1,8 @@
+package orgs
+
+import "github.com/google/uuid"
+
+// GenerateID returns a new UUIDv4 string.
+func GenerateID() string {
+	return uuid.NewString()
+}

--- a/pkg/orgs/organization.go
+++ b/pkg/orgs/organization.go
@@ -2,8 +2,10 @@ package orgs
 
 // Organization represents a collection of resources under a single tenant.
 type Organization struct {
-	ID   string `json:"id" gorm:"primaryKey;size:255"`
-	Name string `json:"name" gorm:"not null"`
+	ID     string `json:"id" gorm:"primaryKey;size:255;default:uuid_generate_v4()"`
+	Name   string `json:"name" gorm:"not null"`
+	Domain string `json:"domain" gorm:"not null"`
+	Email  string `json:"email" gorm:"not null"`
 }
 
 func (Organization) TableName() string { return "organizations" }

--- a/pkg/orgs/store.go
+++ b/pkg/orgs/store.go
@@ -42,6 +42,9 @@ type PostgresStore struct {
 func (s *MemoryStore) Create(o Organization) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if o.ID == "" {
+		o.ID = GenerateID()
+	}
 	if _, ok := s.orgs[o.ID]; ok {
 		return ErrOrgExists
 	}
@@ -95,6 +98,9 @@ func (s *MemoryStore) List() []Organization {
 
 // Create inserts an organization into the database.
 func (s *PostgresStore) Create(o Organization) error {
+	if o.ID == "" {
+		o.ID = GenerateID()
+	}
 	if err := s.db.Create(&o).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return ErrOrgExists

--- a/pkg/users/id.go
+++ b/pkg/users/id.go
@@ -1,0 +1,8 @@
+package users
+
+import "github.com/google/uuid"
+
+// GenerateID returns a new UUIDv4 string.
+func GenerateID() string {
+	return uuid.NewString()
+}

--- a/pkg/users/store.go
+++ b/pkg/users/store.go
@@ -43,6 +43,9 @@ type PostgresStore struct {
 func (s *MemoryStore) Create(u User) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if u.ID == "" {
+		u.ID = GenerateID()
+	}
 	if _, ok := s.users[u.ID]; ok {
 		return ErrUserExists
 	}
@@ -102,6 +105,9 @@ func (s *MemoryStore) Update(u User) error {
 
 // Create inserts a new user into the database.
 func (s *PostgresStore) Create(u User) error {
+	if u.ID == "" {
+		u.ID = GenerateID()
+	}
 	if err := s.db.Create(&u).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return ErrUserExists

--- a/pkg/users/user.go
+++ b/pkg/users/user.go
@@ -2,7 +2,9 @@ package users
 
 // User represents an API user able to authenticate to Bifrost.
 type User struct {
-	ID     string `json:"id" gorm:"primaryKey;size:255"`
+	ID     string `json:"id" gorm:"primaryKey;size:255;default:uuid_generate_v4()"`
+	Name   string `json:"name" gorm:"not null"`
+	Email  string `json:"email" gorm:"not null"`
 	APIKey string `json:"api_key" gorm:"not null"`
 }
 

--- a/routes/users.go
+++ b/routes/users.go
@@ -17,7 +17,8 @@ var UserStore users.Store
 // CreateUser handles POST /users and generates an API key.
 func CreateUser(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		ID      string `json:"id"`
+		Name    string `json:"name"`
+		Email   string `json:"email"`
 		OrgID   string `json:"org_id"`
 		OrgName string `json:"org_name"`
 		Role    string `json:"role"`
@@ -26,7 +27,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
-	if req.ID == "" {
+	if req.Name == "" || req.Email == "" {
 		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
@@ -40,7 +41,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	u := users.User{ID: req.ID, APIKey: users.GenerateAPIKey()}
+	u := users.User{ID: users.GenerateID(), Name: req.Name, Email: req.Email, APIKey: users.GenerateAPIKey()}
 	if err := UserStore.Create(u); err != nil {
 		switch err {
 		case users.ErrUserExists:
@@ -53,7 +54,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 
 	var orgID string
 	if req.OrgName != "" && req.OrgID == "" {
-		o := orgs.Organization{ID: users.GenerateAPIKey(), Name: req.OrgName}
+		o := orgs.Organization{ID: orgs.GenerateID(), Name: req.OrgName}
 		if err := OrgStore.Create(o); err != nil {
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return

--- a/tests/auth_org_context_test.go
+++ b/tests/auth_org_context_test.go
@@ -58,16 +58,16 @@ func TestUserCreationOrgContext(t *testing.T) {
 			routes.OrgStore = orgs.NewMemoryStore()
 			routes.MembershipStore = orgs.NewMembershipStore()
 
-			admin := users.User{ID: "admin", APIKey: "admink"}
+			admin := users.User{ID: "admin", Name: "Admin", Email: "admin@example.com", APIKey: "admink"}
 			routes.UserStore.Create(admin)
 
 			if tc.orgID != "" {
-				routes.OrgStore.Create(orgs.Organization{ID: tc.orgID, Name: "Existing Org"})
+				routes.OrgStore.Create(orgs.Organization{ID: tc.orgID, Name: "Existing Org", Domain: "example.com", Email: "org@example.com"})
 			}
 
 			router := setupOrgCtxRouter()
 
-			payload := map[string]string{"id": "new"}
+			payload := map[string]string{"name": "New", "email": "new@example.com"}
 			if tc.orgName != "" {
 				payload["org_name"] = tc.orgName
 			}
@@ -142,8 +142,8 @@ func TestUserCreationOrgContext(t *testing.T) {
 }
 
 func TestOrgCtxMiddlewareFailures(t *testing.T) {
-	u := users.User{ID: "u1", APIKey: "secret"}
-	o := orgs.Organization{ID: "o1", Name: "Org"}
+	u := users.User{ID: "u1", Name: "User1", Email: "u1@example.com", APIKey: "secret"}
+	o := orgs.Organization{ID: "o1", Name: "Org", Domain: "example.com", Email: "org@example.com"}
 
 	cases := []struct {
 		name  string

--- a/tests/keys_test.go
+++ b/tests/keys_test.go
@@ -21,7 +21,7 @@ func TestCreateKey(t *testing.T) {
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {
@@ -58,7 +58,7 @@ func TestCreateKey(t *testing.T) {
 func TestDeleteKey(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	k := keys.VirtualKey{ID: "dead", Scope: "x", Target: "svc", ExpiresAt: time.Now(), RateLimit: 1}
 	if err := routes.KeyStore.Create(k); err != nil {
@@ -86,7 +86,7 @@ func TestCreateKeyExampleJSON(t *testing.T) {
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk2", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {

--- a/tests/orgs_test.go
+++ b/tests/orgs_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCreateGetOrg(t *testing.T) {
 	routes.OrgStore = orgs.NewMemoryStore()
-	o := orgs.Organization{ID: "org1", Name: "Test Org"}
+	o := orgs.Organization{ID: "org1", Name: "Test Org", Domain: "example.com", Email: "org@example.com"}
 	if err := routes.OrgStore.Create(o); err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -24,11 +24,11 @@ func TestCreateGetOrg(t *testing.T) {
 
 func TestUpdateOrg(t *testing.T) {
 	routes.OrgStore = orgs.NewMemoryStore()
-	o := orgs.Organization{ID: "org1", Name: "Old"}
+	o := orgs.Organization{ID: "org1", Name: "Old", Domain: "example.com", Email: "org@example.com"}
 	if err := routes.OrgStore.Create(o); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	updated := orgs.Organization{ID: "org1", Name: "New"}
+	updated := orgs.Organization{ID: "org1", Name: "New", Domain: "example.com", Email: "org@example.com"}
 	if err := routes.OrgStore.Update(updated); err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestUpdateOrg(t *testing.T) {
 
 func TestDeleteOrg(t *testing.T) {
 	routes.OrgStore = orgs.NewMemoryStore()
-	o := orgs.Organization{ID: "org1", Name: "Del"}
+	o := orgs.Organization{ID: "org1", Name: "Del", Domain: "example.com", Email: "org@example.com"}
 	if err := routes.OrgStore.Create(o); err != nil {
 		t.Fatalf("seed: %v", err)
 	}

--- a/tests/proxy_errors_test.go
+++ b/tests/proxy_errors_test.go
@@ -20,7 +20,7 @@ func TestProxyMissingKey(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
 	router := setupRouter()
@@ -43,7 +43,7 @@ func TestProxyInvalidKey(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
 	router := setupRouter()
@@ -67,7 +67,7 @@ func TestProxyExpiredKey(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
 	k := keys.VirtualKey{ID: "expired", Scope: keys.ScopeRead, Target: "svc", ExpiresAt: time.Now().Add(-time.Hour), RateLimit: 1}
@@ -96,7 +96,7 @@ func TestProxyScopeViolation(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
 	called := false

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -31,7 +31,7 @@ func TestProxy(t *testing.T) {
 			routes.KeyStore = keys.NewMemoryStore()
 			routes.RootKeyStore = rootkeys.NewMemoryStore()
 			routes.UserStore = users.NewMemoryStore()
-			u := users.User{ID: "u", APIKey: "secret"}
+			u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 			routes.UserStore.Create(u)
 
 			backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -109,7 +109,7 @@ func TestProxyScopeEnforcement(t *testing.T) {
 			routes.KeyStore = keys.NewMemoryStore()
 			routes.RootKeyStore = rootkeys.NewMemoryStore()
 			routes.UserStore = users.NewMemoryStore()
-			u := users.User{ID: "u", APIKey: "secret"}
+			u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 			routes.UserStore.Create(u)
 
 			called := false

--- a/tests/rate_limit_test.go
+++ b/tests/rate_limit_test.go
@@ -32,7 +32,7 @@ func TestRateLimitExceeded(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/rootkeys_test.go
+++ b/tests/rootkeys_test.go
@@ -15,7 +15,7 @@ import (
 func TestCreateRootKey(t *testing.T) {
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
 
@@ -43,7 +43,7 @@ func TestCreateRootKey(t *testing.T) {
 func TestDeleteRootKey(t *testing.T) {
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "dead", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {
@@ -67,7 +67,7 @@ func TestDeleteRootKey(t *testing.T) {
 func TestUpdateRootKey(t *testing.T) {
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	orig := rootkeys.RootKey{ID: "rk", APIKey: "old"}
 	if err := routes.RootKeyStore.Create(orig); err != nil {

--- a/tests/routes_errors_test.go
+++ b/tests/routes_errors_test.go
@@ -19,7 +19,7 @@ import (
 func TestCreateKeyInvalidJSON(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
 
@@ -42,7 +42,7 @@ func TestCreateKeyDuplicate(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	svc := services.Service{ID: "svc", Endpoint: "http://example.com", RootKeyID: "rk"}
 	if err := routes.ServiceStore.Create(svc); err != nil {
@@ -73,7 +73,7 @@ func TestCreateKeyDuplicate(t *testing.T) {
 func TestDeleteKeyNotFound(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
 
@@ -96,7 +96,7 @@ func TestCreateKeyMissingService(t *testing.T) {
 	routes.KeyStore = keys.NewMemoryStore()
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
 
@@ -126,7 +126,7 @@ func TestCreateKeyInvalidScope(t *testing.T) {
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk-scope", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {
@@ -159,7 +159,7 @@ func TestCreateKeyEmptyScope(t *testing.T) {
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk-empty", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {
@@ -192,7 +192,7 @@ func TestCreateKeyPastExpiration(t *testing.T) {
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk-exp", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -72,7 +72,7 @@ func TestVersion(t *testing.T) {
 
 func TestV1Hello(t *testing.T) {
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	router := setupRouter()
 	req := httptest.NewRequest(http.MethodGet, "/v1/hello", nil)

--- a/tests/services_test.go
+++ b/tests/services_test.go
@@ -17,7 +17,7 @@ func TestCreateService(t *testing.T) {
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rk", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {
@@ -50,7 +50,7 @@ func TestDeleteService(t *testing.T) {
 	routes.ServiceStore = services.NewMemoryStore()
 	routes.RootKeyStore = rootkeys.NewMemoryStore()
 	routes.UserStore = users.NewMemoryStore()
-	u := users.User{ID: "u", APIKey: "secret"}
+	u := users.User{ID: "u", Name: "U", Email: "u@example.com", APIKey: "secret"}
 	routes.UserStore.Create(u)
 	rk := rootkeys.RootKey{ID: "rkdead", APIKey: "k"}
 	if err := routes.RootKeyStore.Create(rk); err != nil {

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -19,12 +19,12 @@ func TestCreateUserReturnsToken(t *testing.T) {
 	routes.OrgStore = orgs.NewMemoryStore()
 	routes.MembershipStore = orgs.NewMembershipStore()
 
-	admin := users.User{ID: "admin", APIKey: "secret"}
+	admin := users.User{ID: "admin", Name: "Admin", Email: "admin@example.com", APIKey: "secret"}
 	routes.UserStore.Create(admin)
 
 	router := setupRouter()
 
-	payload := `{"id":"new"}`
+	payload := `{"name":"New User","email":"new@example.com"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/users", strings.NewReader(payload))
 	req.Header.Set("X-API-Key", admin.APIKey)
 	req.Header.Set("Authorization", "Bearer "+makeToken(admin.ID))
@@ -42,8 +42,11 @@ func TestCreateUserReturnsToken(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.ID != "new" {
-		t.Fatalf("unexpected id: %s", resp.ID)
+	if resp.ID == "" {
+		t.Fatalf("missing id")
+	}
+	if resp.Name != "New User" || resp.Email != "new@example.com" {
+		t.Fatalf("unexpected user data: %#v", resp.User)
 	}
 	if resp.Token == "" {
 		t.Fatalf("missing token")


### PR DESCRIPTION
## Summary
- generate UUIDs for user and organization IDs
- store name/email for users
- add domain/email fields for organizations
- update routes and tests for new schemas
- include migrations for new columns

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_685785c55938832ab45e5996125a935d