### PR TITLE
Fix init-admin build

### DIFF
--- a/cmd/bifrost/init_admin.go
+++ b/cmd/bifrost/init_admin.go
@@ -11,8 +11,10 @@ import (
 )
 
 var (
-	initAdminName  string
-	initAdminEmail string
+	initAdminName    string
+	initAdminEmail   string
+	initAdminOrgID   string
+	initAdminOrgName string
 )
 
 var initAdminCmd = &cobra.Command{
@@ -60,5 +62,7 @@ var initAdminCmd = &cobra.Command{
 func init() {
 	initAdminCmd.Flags().StringVar(&initAdminName, "name", config.AdminName(), "admin user name")
 	initAdminCmd.Flags().StringVar(&initAdminEmail, "email", config.AdminEmail(), "admin user email")
+	initAdminCmd.Flags().StringVar(&initAdminOrgID, "org-id", config.AdminOrgID(), "admin organization id")
+	initAdminCmd.Flags().StringVar(&initAdminOrgName, "org-name", config.AdminOrgName(), "admin organization name")
 	rootCmd.AddCommand(initAdminCmd)
 }

--- a/config/README.md
+++ b/config/README.md
@@ -13,5 +13,7 @@ environment variables. Key variables include:
 - `BIFROST_ADMIN_API_KEY` – API key for the admin, random when unset
 - `BIFROST_ADMIN_NAME` – name for the admin user, defaults to `Admin`
 - `BIFROST_ADMIN_EMAIL` – email for the admin user, defaults to `admin@example.com`
+- `BIFROST_ADMIN_ORG_ID` – ID for the admin organization (default `admin-org`)
+- `BIFROST_ADMIN_ORG_NAME` – name for the admin organization (default `Admin`)
 
 See the project `README.md` for more details and examples.

--- a/config/config.go
+++ b/config/config.go
@@ -96,3 +96,23 @@ func AdminEmail() string {
 	}
 	return email
 }
+
+// AdminOrgID returns the ID for the initial admin organization.
+// It reads BIFROST_ADMIN_ORG_ID and defaults to "admin-org" when unset.
+func AdminOrgID() string {
+	id := os.Getenv("BIFROST_ADMIN_ORG_ID")
+	if id == "" {
+		id = "admin-org"
+	}
+	return id
+}
+
+// AdminOrgName returns the name for the initial admin organization.
+// It reads BIFROST_ADMIN_ORG_NAME and defaults to "Admin" when unset.
+func AdminOrgName() string {
+	name := os.Getenv("BIFROST_ADMIN_ORG_NAME")
+	if name == "" {
+		name = "Admin"
+	}
+	return name
+}


### PR DESCRIPTION
## Summary
- add missing admin org config helpers
- expose init-admin flags for organization
- document admin org env vars

## Testing
- `go fmt ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_685795709f44832ab858b2bd9d145682