### PR TITLE
Remove orgId from init_admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ Bifrost can be configured through the following environment variables:
 | `BIFROST_ADMIN_API_KEY` | API key for the admin user | random |
 | `BIFROST_ADMIN_NAME` | name for the admin user | `Admin` |
 | `BIFROST_ADMIN_EMAIL` | email for the admin user | `admin@example.com` |
-| `BIFROST_ADMIN_ORG_ID` | ID for the admin organization | `admin-org` |
 | `BIFROST_ADMIN_ORG_NAME` | name of the admin organization | `Admin` |
 
 Use these variables to control the verbosity and choose between machine-readable JSON logs or a console-friendly format.

--- a/cmd/bifrost/init_admin.go
+++ b/cmd/bifrost/init_admin.go
@@ -13,7 +13,6 @@ import (
 var (
 	initAdminName    string
 	initAdminEmail   string
-	initAdminOrgID   string
 	initAdminOrgName string
 )
 
@@ -33,7 +32,7 @@ var initAdminCmd = &cobra.Command{
 		defer sqlDB.Close()
 
 		orgStore := orgs.NewPostgresStore(db)
-		o := orgs.Organization{ID: initAdminOrgID, Name: initAdminOrgName}
+		o := orgs.Organization{Name: initAdminOrgName}
 		if err := orgStore.Create(o); err != nil && err != orgs.ErrOrgExists {
 			return err
 		}
@@ -62,7 +61,6 @@ var initAdminCmd = &cobra.Command{
 func init() {
 	initAdminCmd.Flags().StringVar(&initAdminName, "name", config.AdminName(), "admin user name")
 	initAdminCmd.Flags().StringVar(&initAdminEmail, "email", config.AdminEmail(), "admin user email")
-	initAdminCmd.Flags().StringVar(&initAdminOrgID, "org-id", config.AdminOrgID(), "admin organization id")
 	initAdminCmd.Flags().StringVar(&initAdminOrgName, "org-name", config.AdminOrgName(), "admin organization name")
 	rootCmd.AddCommand(initAdminCmd)
 }

--- a/config/README.md
+++ b/config/README.md
@@ -13,7 +13,6 @@ environment variables. Key variables include:
 - `BIFROST_ADMIN_API_KEY` – API key for the admin, random when unset
 - `BIFROST_ADMIN_NAME` – name for the admin user, defaults to `Admin`
 - `BIFROST_ADMIN_EMAIL` – email for the admin user, defaults to `admin@example.com`
-- `BIFROST_ADMIN_ORG_ID` – ID for the admin organization (default `admin-org`)
 - `BIFROST_ADMIN_ORG_NAME` – name for the admin organization (default `Admin`)
 
 See the project `README.md` for more details and examples.

--- a/config/config.go
+++ b/config/config.go
@@ -97,16 +97,6 @@ func AdminEmail() string {
 	return email
 }
 
-// AdminOrgID returns the ID for the initial admin organization.
-// It reads BIFROST_ADMIN_ORG_ID and defaults to "admin-org" when unset.
-func AdminOrgID() string {
-	id := os.Getenv("BIFROST_ADMIN_ORG_ID")
-	if id == "" {
-		id = "admin-org"
-	}
-	return id
-}
-
 // AdminOrgName returns the name for the initial admin organization.
 // It reads BIFROST_ADMIN_ORG_NAME and defaults to "Admin" when unset.
 func AdminOrgName() string {


### PR DESCRIPTION
## Summary
- remove org-id flag from `init-admin` command and rely on auto-generated IDs
- drop unused `AdminOrgID` config helper
- update documentation to remove `BIFROST_ADMIN_ORG_ID`

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685799518454832a8138b3c99b751a74