### PR TITLE
Add setup job to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Redis and PostgreSQL. Make sure both **Docker** and **Docker Compose** are insta
 docker-compose up -d
 ```
 
+The stack runs a one-off `setup-job` that creates an `admin` user in the
+`demo-org` organization. The `bifrost` service only starts once this job
+completes successfully.
+
 This brings up the stack in the background on the default ports. When finished,
 tear it down with:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
         condition: service_started
       postgres:
         condition: service_healthy
+      setup-job:
+        condition: service_completed_successfully
     networks:
       - internal
 
@@ -24,6 +26,23 @@ services:
       REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
       POSTGRES_DSN: ${POSTGRES_DSN:-postgres://bifrost:bifrost@postgres:5432/bifrost?sslmode=disable}
     entrypoint: ["/app/bifrost-cli"]
+    networks:
+      - internal
+
+  setup-job:
+    build: .
+    environment:
+      BIFROST_PORT: "3333"
+      REDIS_ADDR: ${REDIS_ADDR:-redis:6379}
+      POSTGRES_DSN: ${POSTGRES_DSN:-postgres://bifrost:bifrost@postgres:5432/bifrost?sslmode=disable}
+    entrypoint: ["/app/bifrost-cli"]
+    command: ["user-add", "--name", "admin", "--org-name", "demo-org", "--email", "admin@admin.com"]
+    depends_on:
+      redis:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    restart: "no"
     networks:
       - internal
 


### PR DESCRIPTION
## Summary
- create `setup-job` service in docker-compose to initialize an admin user
- make `bifrost` wait for the job to complete
- document the setup job in the README

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6858314751fc832a827d154910ef868d