### PR TITLE
Refactor ID generation

### DIFF
--- a/pkg/orgs/id.go
+++ b/pkg/orgs/id.go
@@ -1,8 +1,0 @@
-package orgs
-
-import "github.com/google/uuid"
-
-// GenerateID returns a new UUIDv4 string.
-func GenerateID() string {
-	return uuid.NewString()
-}

--- a/pkg/orgs/store.go
+++ b/pkg/orgs/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/farovictor/bifrost/pkg/utils"
 	"gorm.io/gorm"
 )
 
@@ -43,7 +44,7 @@ func (s *MemoryStore) Create(o Organization) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if o.ID == "" {
-		o.ID = GenerateID()
+		o.ID = utils.GenerateID()
 	}
 	if _, ok := s.orgs[o.ID]; ok {
 		return ErrOrgExists
@@ -99,7 +100,7 @@ func (s *MemoryStore) List() []Organization {
 // Create inserts an organization into the database.
 func (s *PostgresStore) Create(o Organization) error {
 	if o.ID == "" {
-		o.ID = GenerateID()
+		o.ID = utils.GenerateID()
 	}
 	if err := s.db.Create(&o).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {

--- a/pkg/users/store.go
+++ b/pkg/users/store.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/farovictor/bifrost/pkg/utils"
 	"gorm.io/gorm"
 )
 
@@ -44,7 +45,7 @@ func (s *MemoryStore) Create(u User) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if u.ID == "" {
-		u.ID = GenerateID()
+		u.ID = utils.GenerateID()
 	}
 	if _, ok := s.users[u.ID]; ok {
 		return ErrUserExists
@@ -106,7 +107,7 @@ func (s *MemoryStore) Update(u User) error {
 // Create inserts a new user into the database.
 func (s *PostgresStore) Create(u User) error {
 	if u.ID == "" {
-		u.ID = GenerateID()
+		u.ID = utils.GenerateID()
 	}
 	if err := s.db.Create(&u).Error; err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,4 +1,5 @@
-package users
+// Package utils provides helper functions used across the project.
+package utils
 
 import "github.com/google/uuid"
 

--- a/routes/users.go
+++ b/routes/users.go
@@ -9,6 +9,7 @@ import (
 	"github.com/farovictor/bifrost/pkg/logging"
 	"github.com/farovictor/bifrost/pkg/orgs"
 	"github.com/farovictor/bifrost/pkg/users"
+	"github.com/farovictor/bifrost/pkg/utils"
 )
 
 // UserStore provides access to persisted users.
@@ -41,7 +42,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	u := users.User{ID: users.GenerateID(), Name: req.Name, Email: req.Email, APIKey: users.GenerateAPIKey()}
+	u := users.User{ID: utils.GenerateID(), Name: req.Name, Email: req.Email, APIKey: users.GenerateAPIKey()}
 	if err := UserStore.Create(u); err != nil {
 		switch err {
 		case users.ErrUserExists:
@@ -54,7 +55,7 @@ func CreateUser(w http.ResponseWriter, r *http.Request) {
 
 	var orgID string
 	if req.OrgName != "" && req.OrgID == "" {
-		o := orgs.Organization{ID: orgs.GenerateID(), Name: req.OrgName}
+		o := orgs.Organization{ID: utils.GenerateID(), Name: req.OrgName}
 		if err := OrgStore.Create(o); err != nil {
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Summary
- centralize UUID creation in `pkg/utils`
- use the new helper in user and org stores
- update user routes to rely on the shared ID generator
- remove obsolete `id.go` files

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_685831f125a8832a820518745568bed2