### PR TITLE
Use env signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Bifrost can be configured through the following environment variables:
 | `BIFROST_LOG_LEVEL` | log level (`debug`, `info`, `warn`, `error`) | `info` |
 | `BIFROST_LOG_FORMAT` | log output format (`json` or `console`) | `json` |
 | `BIFROST_ENABLE_METRICS` | expose Prometheus metrics | `false` |
+| `BIFROST_SIGNING_KEY` | base64 HMAC key for auth tokens | random each start |
 | `BIFROST_ADMIN_API_KEY` | API key for the admin user | random |
 | `BIFROST_ADMIN_NAME` | name for the admin user | `Admin` |
 | `BIFROST_ADMIN_EMAIL` | email for the admin user | `admin@example.com` |

--- a/config/README.md
+++ b/config/README.md
@@ -10,6 +10,7 @@ environment variables. Key variables include:
 - `REDIS_PROTOCOL` – Redis protocol version (default `3`)
 - `POSTGRES_DSN` – Postgres connection string
 - `BIFROST_ENABLE_METRICS` – enable Prometheus metrics when set
+- `BIFROST_SIGNING_KEY` – base64 HMAC key for auth tokens, random when unset
 - `BIFROST_ADMIN_API_KEY` – API key for the admin, random when unset
 - `BIFROST_ADMIN_NAME` – name for the admin user, defaults to `Admin`
 - `BIFROST_ADMIN_EMAIL` – email for the admin user, defaults to `admin@example.com`

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"os"
 	"strings"
 	"time"
 )
@@ -18,7 +19,19 @@ type AuthToken struct {
 	ExpiresAt time.Time `json:"expires_at"`
 }
 
-var signingKey = generateKey()
+var signingKey = loadKey()
+
+// loadKey returns the signing key from the BIFROST_SIGNING_KEY environment
+// variable. If the variable is empty or invalid base64, a random key is
+// generated instead.
+func loadKey() []byte {
+	if v := os.Getenv("BIFROST_SIGNING_KEY"); v != "" {
+		if b, err := base64.StdEncoding.DecodeString(v); err == nil {
+			return b
+		}
+	}
+	return generateKey()
+}
 
 // generateKey creates a new random signing key.
 func generateKey() []byte {


### PR DESCRIPTION
## Summary
- load auth signing key from `BIFROST_SIGNING_KEY`
- document `BIFROST_SIGNING_KEY` environment variable

## Testing
- `go fmt ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_685848e1bd38832aa297ab6c9d943117