### PR TITLE
Log warning when signing key invalid

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/farovictor/bifrost/pkg/logging"
 )
 
 // AuthToken represents an authentication token for API users.
@@ -25,12 +27,19 @@ var signingKey = loadKey()
 // variable. If the variable is empty or invalid base64, a random key is
 // generated instead.
 func loadKey() []byte {
-	if v := os.Getenv("BIFROST_SIGNING_KEY"); v != "" {
-		if b, err := base64.StdEncoding.DecodeString(v); err == nil {
-			return b
-		}
+	v := os.Getenv("BIFROST_SIGNING_KEY")
+	if v == "" {
+		logging.Logger.Warn().Msg("BIFROST_SIGNING_KEY not set, generating random key")
+		return generateKey()
 	}
-	return generateKey()
+
+	b, err := base64.StdEncoding.DecodeString(v)
+	if err != nil {
+		logging.Logger.Warn().Err(err).Msg("invalid BIFROST_SIGNING_KEY, generating random key")
+		return generateKey()
+	}
+
+	return b
 }
 
 // generateKey creates a new random signing key.

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/farovictor/bifrost/pkg/logging"
+	"github.com/rs/zerolog"
+)
+
+func TestLoadKeyWarnInvalid(t *testing.T) {
+	old := os.Getenv("BIFROST_SIGNING_KEY")
+	t.Cleanup(func() {
+		os.Setenv("BIFROST_SIGNING_KEY", old)
+	})
+	os.Setenv("BIFROST_SIGNING_KEY", "invalid")
+
+	var buf bytes.Buffer
+	logging.Logger = zerolog.New(&buf)
+
+	loadKey()
+
+	if !strings.Contains(buf.String(), "invalid BIFROST_SIGNING_KEY") {
+		t.Fatalf("warning not logged: %s", buf.String())
+	}
+}
+
+func TestLoadKeyWarnEmpty(t *testing.T) {
+	old := os.Getenv("BIFROST_SIGNING_KEY")
+	t.Cleanup(func() {
+		os.Setenv("BIFROST_SIGNING_KEY", old)
+	})
+	os.Unsetenv("BIFROST_SIGNING_KEY")
+
+	var buf bytes.Buffer
+	logging.Logger = zerolog.New(&buf)
+
+	loadKey()
+
+	if !strings.Contains(buf.String(), "BIFROST_SIGNING_KEY not set") {
+		t.Fatalf("warning not logged: %s", buf.String())
+	}
+}

--- a/routes/users.go
+++ b/routes/users.go
@@ -119,8 +119,8 @@ func GetUserInfo(w http.ResponseWriter, r *http.Request) {
 	}
 	raw := strings.TrimPrefix(authHeader, "Bearer ")
 	tok, err := auth.Verify(raw)
-	logging.Logger.Error().Str("error", err.Error())
 	if err != nil {
+		logging.Logger.Error().Err(err).Msg("verify token")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
## Summary
- warn when BIFROST_SIGNING_KEY is missing or invalid
- fix user info handler to log errors only when present
- test that invalid signing key logs a warning

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685884b03684832a8e93eefddaa68916