### PR TITLE
Fix membership lookup in user info

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 		routes.RootKeyStore = rootkeys.NewMemoryStore()
 		routes.ServiceStore = services.NewMemoryStore()
 		routes.OrgStore = orgs.NewMemoryStore()
-		routes.MembershipStore = orgs.NewMembershipStore()
+		routes.MembershipStore = orgs.NewMemoryMembershipStore()
 		logging.Logger.Info().Msg("In-Memory Store set")
 	} else {
 		db, err := database.Connect(dsn)
@@ -48,7 +48,7 @@ func main() {
 		routes.RootKeyStore = rootkeys.NewPostgresStore(db)
 		routes.ServiceStore = services.NewPostgresStore(db)
 		routes.OrgStore = orgs.NewPostgresStore(db)
-		routes.MembershipStore = orgs.NewMembershipStore()
+		routes.MembershipStore = orgs.NewPostgresMembershipStore(db)
 		logging.Logger.Info().Msg("Postgres Store set")
 	}
 

--- a/pkg/orgs/membership_pg_store.go
+++ b/pkg/orgs/membership_pg_store.go
@@ -7,7 +7,7 @@ import (
 )
 
 // PostgresMembershipStore persists memberships in PostgreSQL.
-// It mirrors the in-memory MembershipStore behavior.
+// It mirrors the in-memory MemoryMembershipStore behavior.
 type PostgresMembershipStore struct {
 	db *gorm.DB
 }
@@ -69,6 +69,15 @@ func (s *PostgresMembershipStore) Update(m Membership) error {
 func (s *PostgresMembershipStore) List() []Membership {
 	var out []Membership
 	if err := s.db.Find(&out).Error; err != nil {
+		return nil
+	}
+	return out
+}
+
+// ListByUser returns memberships for a specific user.
+func (s *PostgresMembershipStore) ListByUser(userID string) []Membership {
+	var out []Membership
+	if err := s.db.Where("user_id = ?", userID).Find(&out).Error; err != nil {
 		return nil
 	}
 	return out

--- a/pkg/orgs/membership_store.go
+++ b/pkg/orgs/membership_store.go
@@ -5,15 +5,25 @@ import (
 	"sync"
 )
 
-// MembershipStore keeps Memberships in memory with concurrency safety.
-type MembershipStore struct {
+// MembershipStore defines persistence behavior for Membership objects.
+type MembershipStore interface {
+	Create(Membership) error
+	Get(userID, orgID string) (Membership, error)
+	Delete(userID, orgID string) error
+	Update(Membership) error
+	List() []Membership
+	ListByUser(userID string) []Membership
+}
+
+// MemoryMembershipStore keeps memberships in memory with concurrency safety.
+type MemoryMembershipStore struct {
 	mu          sync.RWMutex
 	memberships map[string]Membership
 }
 
-// NewMembershipStore creates an initialized MembershipStore.
-func NewMembershipStore() *MembershipStore {
-	return &MembershipStore{memberships: make(map[string]Membership)}
+// NewMemoryMembershipStore creates an initialized MemoryMembershipStore.
+func NewMemoryMembershipStore() *MemoryMembershipStore {
+	return &MemoryMembershipStore{memberships: make(map[string]Membership)}
 }
 
 func membershipKey(userID, orgID string) string {
@@ -21,7 +31,7 @@ func membershipKey(userID, orgID string) string {
 }
 
 // Create inserts a new Membership. Returns error if the user/org pair already exists.
-func (s *MembershipStore) Create(m Membership) error {
+func (s *MemoryMembershipStore) Create(m Membership) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	k := membershipKey(m.UserID, m.OrgID)
@@ -33,7 +43,7 @@ func (s *MembershipStore) Create(m Membership) error {
 }
 
 // Get retrieves a Membership by user and organization IDs.
-func (s *MembershipStore) Get(userID, orgID string) (Membership, error) {
+func (s *MemoryMembershipStore) Get(userID, orgID string) (Membership, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	k := membershipKey(userID, orgID)
@@ -45,7 +55,7 @@ func (s *MembershipStore) Get(userID, orgID string) (Membership, error) {
 }
 
 // Delete removes a Membership from the store.
-func (s *MembershipStore) Delete(userID, orgID string) error {
+func (s *MemoryMembershipStore) Delete(userID, orgID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	k := membershipKey(userID, orgID)
@@ -57,7 +67,7 @@ func (s *MembershipStore) Delete(userID, orgID string) error {
 }
 
 // Update replaces an existing Membership.
-func (s *MembershipStore) Update(m Membership) error {
+func (s *MemoryMembershipStore) Update(m Membership) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	k := membershipKey(m.UserID, m.OrgID)
@@ -69,12 +79,25 @@ func (s *MembershipStore) Update(m Membership) error {
 }
 
 // List returns all Memberships currently in the store.
-func (s *MembershipStore) List() []Membership {
+func (s *MemoryMembershipStore) List() []Membership {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make([]Membership, 0, len(s.memberships))
 	for _, m := range s.memberships {
 		out = append(out, m)
+	}
+	return out
+}
+
+// ListByUser returns memberships belonging to userID.
+func (s *MemoryMembershipStore) ListByUser(userID string) []Membership {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Membership, 0)
+	for _, m := range s.memberships {
+		if m.UserID == userID {
+			out = append(out, m)
+		}
 	}
 	return out
 }

--- a/routes/orgs.go
+++ b/routes/orgs.go
@@ -5,5 +5,5 @@ import "github.com/farovictor/bifrost/pkg/orgs"
 // OrgStore provides access to organizations.
 var OrgStore orgs.Store
 
-// MembershipStore holds organization memberships in memory.
-var MembershipStore = orgs.NewMembershipStore()
+// MembershipStore provides access to organization memberships.
+var MembershipStore orgs.MembershipStore = orgs.NewMemoryMembershipStore()

--- a/routes/users.go
+++ b/routes/users.go
@@ -141,10 +141,7 @@ func GetUserInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var orgsInfo []orgInfo
-	for _, m := range MembershipStore.List() {
-		if m.UserID != u.ID {
-			continue
-		}
+	for _, m := range MembershipStore.ListByUser(u.ID) {
 		if o, err := OrgStore.Get(m.OrgID); err == nil {
 			orgsInfo = append(orgsInfo, orgInfo{OrgID: o.ID, Name: o.Name, Role: m.Role})
 		}

--- a/tests/auth_org_context_test.go
+++ b/tests/auth_org_context_test.go
@@ -58,7 +58,7 @@ func TestUserCreationOrgContext(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			routes.UserStore = users.NewMemoryStore()
 			routes.OrgStore = orgs.NewMemoryStore()
-			routes.MembershipStore = orgs.NewMembershipStore()
+			routes.MembershipStore = orgs.NewMemoryMembershipStore()
 
 			admin := users.User{ID: "admin", Name: "Admin", Email: "admin@example.com", APIKey: "admink"}
 			routes.UserStore.Create(admin)
@@ -176,7 +176,7 @@ func TestOrgCtxMiddlewareFailures(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			routes.UserStore = users.NewMemoryStore()
 			routes.OrgStore = orgs.NewMemoryStore()
-			routes.MembershipStore = orgs.NewMembershipStore()
+			routes.MembershipStore = orgs.NewMemoryMembershipStore()
 			routes.UserStore.Create(u)
 			routes.OrgStore.Create(o)
 

--- a/tests/orgs_test.go
+++ b/tests/orgs_test.go
@@ -56,7 +56,7 @@ func TestDeleteOrg(t *testing.T) {
 }
 
 func TestCreateGetMembership(t *testing.T) {
-	routes.MembershipStore = orgs.NewMembershipStore()
+	routes.MembershipStore = orgs.NewMemoryMembershipStore()
 	m := orgs.Membership{UserID: "u1", OrgID: "o1", Role: orgs.RoleMember}
 	if err := routes.MembershipStore.Create(m); err != nil {
 		t.Fatalf("create: %v", err)
@@ -71,7 +71,7 @@ func TestCreateGetMembership(t *testing.T) {
 }
 
 func TestUpdateMembership(t *testing.T) {
-	routes.MembershipStore = orgs.NewMembershipStore()
+	routes.MembershipStore = orgs.NewMemoryMembershipStore()
 	m := orgs.Membership{UserID: "u1", OrgID: "o1", Role: orgs.RoleMember}
 	if err := routes.MembershipStore.Create(m); err != nil {
 		t.Fatalf("seed: %v", err)
@@ -90,7 +90,7 @@ func TestUpdateMembership(t *testing.T) {
 }
 
 func TestDeleteMembership(t *testing.T) {
-	routes.MembershipStore = orgs.NewMembershipStore()
+	routes.MembershipStore = orgs.NewMemoryMembershipStore()
 	m := orgs.Membership{UserID: "u1", OrgID: "o1", Role: orgs.RoleMember}
 	if err := routes.MembershipStore.Create(m); err != nil {
 		t.Fatalf("seed: %v", err)

--- a/tests/user_info_test.go
+++ b/tests/user_info_test.go
@@ -14,7 +14,7 @@ import (
 func TestGetUserInfo(t *testing.T) {
 	routes.UserStore = users.NewMemoryStore()
 	routes.OrgStore = orgs.NewMemoryStore()
-	routes.MembershipStore = orgs.NewMembershipStore()
+	routes.MembershipStore = orgs.NewMemoryMembershipStore()
 
 	u := users.User{ID: "u1", Name: "User", Email: "u@example.com", APIKey: "key"}
 	routes.UserStore.Create(u)

--- a/tests/users_test.go
+++ b/tests/users_test.go
@@ -17,7 +17,7 @@ import (
 func TestCreateUserReturnsToken(t *testing.T) {
 	routes.UserStore = users.NewMemoryStore()
 	routes.OrgStore = orgs.NewMemoryStore()
-	routes.MembershipStore = orgs.NewMembershipStore()
+	routes.MembershipStore = orgs.NewMemoryMembershipStore()
 
 	admin := users.User{ID: "admin", Name: "Admin", Email: "admin@example.com", APIKey: "secret"}
 	routes.UserStore.Create(admin)


### PR DESCRIPTION
## Summary
- support querying memberships by user
- use membership store's new ListByUser method in GetUserInfo

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685a09e3ca2c832a9ec97f0a16d41669