### PR TITLE
Add helper Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export BIFROST_SIGNING_KEY
 export BIFROST_PORT
 export REDIS_ADDR
 export POSTGRES_DSN
+API_ADDR ?= http://localhost:3333
 
 # setup: Install Go 1.23.8 and project dependencies
 setup:
@@ -22,6 +23,14 @@ run:
 test:
 	go test ./... -coverprofile=coverage.out
 	go tool cover -func=coverage.out
+
+# rootkey-add: Register a root key for local testing
+rootkey-add:
+	go run ./cmd/bifrost rootkey-add --addr $(API_ADDR) --id root --apikey SECRET
+
+# service-add: Register a service for local testing
+service-add: rootkey-add
+	go run ./cmd/bifrost service-add --addr $(API_ADDR) --id svc --endpoint http://localhost:8081 --rootkey root
 
 # compose-up: start Docker Compose environment
 compose-up:

--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ go run ./cmd/bifrost rootkey-delete root
 go run ./cmd/bifrost user-add --id admin --org-name demo-org --role owner
 ```
 
+Makefile shortcuts:
+```bash
+make rootkey-add
+make service-add
+```
 Use `--addr` to specify a custom API address if the server is not running on
 `http://localhost:3333`.
 


### PR DESCRIPTION
## Summary
- add API_ADDR variable
- add rootkey-add and service-add helper rules
- document the rules in the CLI usage docs

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685a28f3d03c832abb821c5151932d55