### PR TITLE
Add bearer token rootkey endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,18 @@ curl -X POST http://localhost:3333/v1/services \
 ### Delete a service
 DELETE `/v1/services/<id>` to remove a service. Include your API key header.
 
+### Add a root key
+POST `/v1/user/rootkeys` with JSON describing the key. Requires only the bearer token.
+
+Example:
+
+```bash
+curl -X POST http://localhost:3333/v1/user/rootkeys \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token>' \
+  -d '{"id":"demo-root","api_key":"SECRET"}'
+```
+
 ### Create a user
 POST `/v1/users` with a JSON body containing the user ID. Optional `org_id` and
 `org_name` fields associate the user with an organization. Provide a `role`

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 		// Endpoints that only require the auth token
 		r.With(rl.OrgCtxMiddleware()).Post("/users", routes.CreateUser)
 		r.With(rl.OrgCtxMiddleware()).Get("/user", routes.GetUserInfo)
+		r.With(rl.OrgCtxMiddleware()).Post("/user/rootkeys", routes.CreateRootKey)
 
 		// Endpoints requiring API key and auth token
 		r.Group(func(r chi.Router) {

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -21,6 +21,7 @@ func setupRouter() http.Handler {
 	r.Route("/v1", func(r chi.Router) {
 		r.With(rl.OrgCtxMiddleware()).Post("/users", routes.CreateUser)
 		r.With(rl.OrgCtxMiddleware()).Get("/user", routes.GetUserInfo)
+		r.With(rl.OrgCtxMiddleware()).Post("/user/rootkeys", routes.CreateRootKey)
 
 		r.Group(func(r chi.Router) {
 			r.Use(rl.AuthMiddleware())


### PR DESCRIPTION
## Summary
- add `/v1/user/rootkeys` endpoint that only needs an auth token
- extend tests for new route
- document root key endpoint in README

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_685a992bb254832a913d9a9daa3cca84