### PR TITLE
Add test server module

### DIFF
--- a/testserver/go.mod
+++ b/testserver/go.mod
@@ -1,0 +1,5 @@
+module github.com/farovictor/bifrost/testserver
+
+go 1.23.8
+
+require github.com/go-chi/chi/v5 v5.2.2

--- a/testserver/go.sum
+++ b/testserver/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.2 h1:CMwsvRVTbXVytCk1Wd72Zy1LAsAh9GxMmSNWLHCG618=
+github.com/go-chi/chi/v5 v5.2.2/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/testserver/main.go
+++ b/testserver/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+    "fmt"
+    "log"
+    "net/http"
+    "os"
+
+    "github.com/go-chi/chi/v5"
+)
+
+func main() {
+    port := os.Getenv("TESTSERVER_PORT")
+    if port == "" {
+        port = "8081"
+    }
+
+    r := chi.NewRouter()
+    r.Get("/check", func(w http.ResponseWriter, r *http.Request) {
+        if r.Header.Get("X-API-Key") != "secret" {
+            w.WriteHeader(http.StatusInternalServerError)
+            return
+        }
+        w.WriteHeader(http.StatusOK)
+        fmt.Fprint(w, "pong")
+    })
+
+    addr := ":" + port
+    log.Printf("starting test server on %s", addr)
+    if err := http.ListenAndServe(addr, r); err != nil {
+        log.Fatalf("listen and serve: %v", err)
+    }
+}


### PR DESCRIPTION
## Summary
- add a small `testserver` module
- expose `/check` that validates `X-API-Key` and returns "pong"

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6872e9595050832ab0816f82d0a7a319