### PR TITLE
Add database and mode configuration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Bifrost can be configured through the following environment variables:
 | `BIFROST_LOG_LEVEL` | log level (`debug`, `info`, `warn`, `error`) | `info` |
 | `BIFROST_LOG_FORMAT` | log output format (`json` or `console`) | `json` |
 | `BIFROST_ENABLE_METRICS` | expose Prometheus metrics | `false` |
+| `BIFROST_DB` | database backend (`sqlite` or `postgres`) | `sqlite` |
+| `BIFROST_MODE` | operational mode (`dev`, `prod`, etc.) | *(empty)* |
 | `BIFROST_SIGNING_KEY` | base64 HMAC key for auth tokens | random each start |
 | `BIFROST_ADMIN_API_KEY` | API key for the admin user | random |
 | `BIFROST_ADMIN_NAME` | name for the admin user | `Admin` |
@@ -109,6 +111,14 @@ You can export these variables or prefix them when starting the server.
 ```bash
 BIFROST_PORT=8080 REDIS_ADDR=localhost:6379 make run
 ```
+
+### Command-Line Flags
+
+The server and the `bifrost` CLI accept the following flags, which override
+their corresponding environment variables when provided:
+
+- `--db` (`BIFROST_DB`): database backend to use (`sqlite` or `postgres`).
+- `--mode` (`BIFROST_MODE`): application mode, such as `dev` or `prod`.
 
 ### Virtual Key Format
 

--- a/cmd/bifrost/root.go
+++ b/cmd/bifrost/root.go
@@ -3,18 +3,43 @@ package main
 import (
 	"os"
 
+	"github.com/farovictor/bifrost/config"
 	"github.com/spf13/cobra"
+)
+
+var (
+	dbType     string
+	mode       string
+	serverAddr string
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "bifrost",
 	Short: "Bifrost command line interface",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if dbType != "" {
+			os.Setenv("BIFROST_DB", dbType)
+		}
+		if mode != "" {
+			os.Setenv("BIFROST_MODE", mode)
+		}
+	},
 }
-
-var serverAddr string
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&serverAddr, "addr", "http://localhost:3333", "bifrost API address")
+	rootCmd.PersistentFlags().StringVar(
+		&dbType,
+		"db",
+		config.DBType(),
+		"database backend to use (sqlite or postgres). Flag takes precedence over BIFROST_DB",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&mode,
+		"mode",
+		config.Mode(),
+		"application mode. Flag takes precedence over BIFROST_MODE",
+	)
 	rootCmd.AddCommand(checkCmd)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -136,3 +136,19 @@ func AdminRole() string {
 	}
 	return role
 }
+
+// DBType returns the database backend to use.
+// It reads the BIFROST_DB environment variable and defaults to "sqlite".
+func DBType() string {
+	db := os.Getenv("BIFROST_DB")
+	if db == "" {
+		db = "sqlite"
+	}
+	return db
+}
+
+// Mode returns the operational mode for the application.
+// It reads the BIFROST_MODE environment variable and may be empty if unset.
+func Mode() string {
+	return os.Getenv("BIFROST_MODE")
+}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"flag"
 	"net/http"
+	"os"
 
 	"github.com/farovictor/bifrost/config"
 	rl "github.com/farovictor/bifrost/middlewares"
@@ -27,6 +29,23 @@ func init() {
 }
 
 func main() {
+	dbFlag := flag.String(
+		"db",
+		"",
+		"database backend to use (sqlite or postgres). Flag takes precedence over BIFROST_DB",
+	)
+	modeFlag := flag.String(
+		"mode",
+		"",
+		"application mode. Flag takes precedence over BIFROST_MODE",
+	)
+	flag.Parse()
+	if *dbFlag != "" {
+		os.Setenv("BIFROST_DB", *dbFlag)
+	}
+	if *modeFlag != "" {
+		os.Setenv("BIFROST_MODE", *modeFlag)
+	}
 
 	dsn := config.PostgresDSN()
 	if dsn == "" {


### PR DESCRIPTION
## Summary
- add DBType and Mode helpers for database and mode configuration
- allow CLI and server flags to set BIFROST_DB and BIFROST_MODE
- clarify flag descriptions and document BIFROST_DB/BIFROST_MODE usage

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6897610ae94c832a8198ed7b3358a150