### PR TITLE
Add db type-aware Connect with sqlite support

### DIFF
--- a/cmd/bifrost/init_admin.go
+++ b/cmd/bifrost/init_admin.go
@@ -30,7 +30,7 @@ var initAdminCmd = &cobra.Command{
 		if dsn == "" {
 			return fmt.Errorf("POSTGRES_DSN is not set")
 		}
-		db, err := database.Connect(dsn)
+		db, err := database.Connect(config.DBType(), dsn)
 		if err != nil {
 			return err
 		}

--- a/cmd/bifrost/migrate.go
+++ b/cmd/bifrost/migrate.go
@@ -19,7 +19,7 @@ var migrateCmd = &cobra.Command{
 		if dsn == "" {
 			return fmt.Errorf("POSTGRES_DSN is not set")
 		}
-		db, err := database.Connect(dsn)
+		db, err := database.Connect(config.DBType(), dsn)
 		if err != nil {
 			return err
 		}

--- a/pkg/database/README.md
+++ b/pkg/database/README.md
@@ -1,5 +1,6 @@
 # Database Connection
 
 The `database` package exposes helpers to create a `*gorm.DB` instance.
-It opens the connection using the provided DSN and verifies that the
-underlying database is reachable.
+It opens the connection using the provided database type and DSN,
+selects the appropriate driver, and verifies that the underlying
+database is reachable.

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1,13 +1,26 @@
 package database
 
 import (
+	"fmt"
+
 	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
 
-// Connect opens a Postgres connection using GORM and verifies it.
-func Connect(dsn string) (*gorm.DB, error) {
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+// Connect opens a database connection using GORM and verifies it.
+func Connect(dbType, dsn string) (*gorm.DB, error) {
+	var dialector gorm.Dialector
+	switch dbType {
+	case "postgres":
+		dialector = postgres.Open(dsn)
+	case "sqlite":
+		dialector = sqlite.Open(dsn)
+	default:
+		return nil, fmt.Errorf("unsupported database type: %s", dbType)
+	}
+
+	db, err := gorm.Open(dialector, &gorm.Config{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- add sqlite driver to shared Connect helper
- use db type-aware Connect for all initialization and CLI commands
- refresh database package docs

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68977a60f3d0832a966dfb566eaf4620