### PR TITLE
Bypass auth in test or sqlite mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Bifrost can be configured through the following environment variables:
 | `BIFROST_ADMIN_ORG_EMAIL` | contact email for the admin organization | `admin@example.com` |
 | `BIFROST_ADMIN_ORG_DOMAIN` | domain for the admin organization | `example.com` |
 | `BIFROST_ADMIN_ROLE` | membership role for the admin user | `owner` |
+| `BIFROST_STATIC_API_KEY` | static API key for test or sqlite mode | `secret` |
+
+When running with the SQLite backend or in test mode, the server accepts this
+static API key and skips user lookups.
 
 Use these variables to control the verbosity and choose between machine-readable JSON logs or a console-friendly format.
 

--- a/config/config.go
+++ b/config/config.go
@@ -152,3 +152,13 @@ func DBType() string {
 func Mode() string {
 	return os.Getenv("BIFROST_MODE")
 }
+
+// StaticAPIKey returns the static API key used for test or sqlite modes.
+// It reads BIFROST_STATIC_API_KEY and defaults to "secret" when unset.
+func StaticAPIKey() string {
+	key := os.Getenv("BIFROST_STATIC_API_KEY")
+	if key == "" {
+		key = "secret"
+	}
+	return key
+}

--- a/middlewares/auth.go
+++ b/middlewares/auth.go
@@ -4,11 +4,16 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/farovictor/bifrost/config"
 	routes "github.com/farovictor/bifrost/routes"
 )
 
 // AuthMiddleware validates the API key provided by the client.
+//
+// In test or sqlite modes, authentication is performed using the static API
+// key from config.StaticAPIKey(), and user lookups are skipped.
 func AuthMiddleware() func(http.Handler) http.Handler {
+	bypass := config.Mode() == "test" || config.DBType() == "sqlite"
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			key := r.Header.Get("X-API-Key")
@@ -19,6 +24,15 @@ func AuthMiddleware() func(http.Handler) http.Handler {
 				} else {
 					key = auth
 				}
+			}
+			if bypass {
+				staticKey := config.StaticAPIKey()
+				if staticKey != "" && key != staticKey {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
 			}
 			if key == "" {
 				http.Error(w, "unauthorized", http.StatusUnauthorized)

--- a/tests/auth_org_context_test.go
+++ b/tests/auth_org_context_test.go
@@ -11,6 +11,7 @@ import (
 	rl "github.com/farovictor/bifrost/middlewares"
 	"github.com/go-chi/chi/v5"
 
+	"github.com/farovictor/bifrost/config"
 	"github.com/farovictor/bifrost/pkg/auth"
 	"github.com/farovictor/bifrost/pkg/orgs"
 	"github.com/farovictor/bifrost/pkg/users"
@@ -123,7 +124,7 @@ func TestUserCreationOrgContext(t *testing.T) {
 			}
 
 			req2 := httptest.NewRequest(http.MethodGet, "/v1/ctx", nil)
-			req2.Header.Set("X-API-Key", resp.APIKey)
+			req2.Header.Set("X-API-Key", config.StaticAPIKey())
 			req2.Header.Set("Authorization", "Bearer "+resp.Token)
 			rr2 := httptest.NewRecorder()
 			router.ServeHTTP(rr2, req2)


### PR DESCRIPTION
## Summary
- add static API key configuration
- bypass user lookup in auth middleware when using sqlite or test mode
- document static API key and update tests
- clarify AuthMiddleware doc comment about static API key behavior

## Testing
- `go fmt ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68977e929b24832ab01ea5bc0f640a0a