### PR TITLE
feat: service accounts with scoped virtual key self-provisioning

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -885,6 +885,211 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/service-token": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "Request a virtual key as a service account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service account API key",
+                        "name": "X-Service-Key",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Token request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.servicetokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.servicetokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "missing or invalid X-Service-Key",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "service not in allowed list",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "service not found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/serviceaccounts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "List service accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/serviceaccounts.ServiceAccount"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "Create service account",
+                "parameters": [
+                    {
+                        "description": "Service account to create",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/serviceaccounts.ServiceAccount"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/serviceaccounts.ServiceAccount"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "service account already exists",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/serviceaccounts/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "Delete service account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service account ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/services": {
             "get": {
                 "security": [
@@ -1515,6 +1720,31 @@ const docTemplate = `{
                 "result": {}
             }
         },
+        "routes.servicetokenRequest": {
+            "type": "object",
+            "properties": {
+                "rate_limit": {
+                    "type": "integer"
+                },
+                "service": {
+                    "type": "string"
+                },
+                "ttl_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "routes.servicetokenResponse": {
+            "type": "object",
+            "properties": {
+                "expires_at": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                }
+            }
+        },
         "routes.usageListResponse": {
             "type": "object",
             "properties": {
@@ -1526,6 +1756,26 @@ const docTemplate = `{
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "serviceaccounts.ServiceAccount": {
+            "type": "object",
+            "properties": {
+                "allowed_services": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "api_key": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -879,6 +879,211 @@
                 }
             }
         },
+        "/v1/service-token": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "Request a virtual key as a service account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service account API key",
+                        "name": "X-Service-Key",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
+                        "description": "Token request",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/routes.servicetokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/routes.servicetokenResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "missing or invalid X-Service-Key",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "service not in allowed list",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "service not found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/serviceaccounts": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "List service accounts",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/serviceaccounts.ServiceAccount"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "Create service account",
+                "parameters": [
+                    {
+                        "description": "Service account to create",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/serviceaccounts.ServiceAccount"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/serviceaccounts.ServiceAccount"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "service account already exists",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/v1/serviceaccounts/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "tags": [
+                    "service-accounts"
+                ],
+                "summary": "Delete service account",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Service account ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/routes.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/services": {
             "get": {
                 "security": [
@@ -1509,6 +1714,31 @@
                 "result": {}
             }
         },
+        "routes.servicetokenRequest": {
+            "type": "object",
+            "properties": {
+                "rate_limit": {
+                    "type": "integer"
+                },
+                "service": {
+                    "type": "string"
+                },
+                "ttl_seconds": {
+                    "type": "integer"
+                }
+            }
+        },
+        "routes.servicetokenResponse": {
+            "type": "object",
+            "properties": {
+                "expires_at": {
+                    "type": "string"
+                },
+                "key": {
+                    "type": "string"
+                }
+            }
+        },
         "routes.usageListResponse": {
             "type": "object",
             "properties": {
@@ -1520,6 +1750,26 @@
                 },
                 "total": {
                     "type": "integer"
+                }
+            }
+        },
+        "serviceaccounts.ServiceAccount": {
+            "type": "object",
+            "properties": {
+                "allowed_services": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "api_key": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -138,6 +138,22 @@ definitions:
         type: string
       result: {}
     type: object
+  routes.servicetokenRequest:
+    properties:
+      rate_limit:
+        type: integer
+      service:
+        type: string
+      ttl_seconds:
+        type: integer
+    type: object
+  routes.servicetokenResponse:
+    properties:
+      expires_at:
+        type: string
+      key:
+        type: string
+    type: object
   routes.usageListResponse:
     properties:
       events:
@@ -146,6 +162,19 @@ definitions:
         type: array
       total:
         type: integer
+    type: object
+  serviceaccounts.ServiceAccount:
+    properties:
+      allowed_services:
+        items:
+          type: string
+        type: array
+      api_key:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
     type: object
   services.Service:
     properties:
@@ -720,6 +749,133 @@ paths:
       summary: Update root key
       tags:
       - root-keys
+  /v1/service-token:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Service account API key
+        in: header
+        name: X-Service-Key
+        required: true
+        type: string
+      - description: Token request
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/routes.servicetokenRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/routes.servicetokenResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "401":
+          description: missing or invalid X-Service-Key
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "403":
+          description: service not in allowed list
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "404":
+          description: service not found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      summary: Request a virtual key as a service account
+      tags:
+      - service-accounts
+  /v1/serviceaccounts:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/serviceaccounts.ServiceAccount'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: List service accounts
+      tags:
+      - service-accounts
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Service account to create
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/serviceaccounts.ServiceAccount'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/serviceaccounts.ServiceAccount'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "409":
+          description: service account already exists
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Create service account
+      tags:
+      - service-accounts
+  /v1/serviceaccounts/{id}:
+    delete:
+      parameters:
+      - description: Service account ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/routes.ErrorResponse'
+      security:
+      - ApiKeyAuth: []
+      - BearerAuth: []
+      summary: Delete service account
+      tags:
+      - service-accounts
   /v1/services:
     get:
       produces:

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/farovictor/bifrost/pkg/metrics"
 	"github.com/farovictor/bifrost/pkg/orgs"
 	"github.com/farovictor/bifrost/pkg/rootkeys"
+	"github.com/farovictor/bifrost/pkg/serviceaccounts"
 	"github.com/farovictor/bifrost/pkg/services"
 	"github.com/farovictor/bifrost/pkg/usage"
 	"github.com/farovictor/bifrost/pkg/users"
@@ -68,6 +69,7 @@ func main() {
 			&orgs.Organization{},
 			&orgs.Membership{},
 			&usage.Event{},
+			&serviceaccounts.ServiceAccount{},
 		); err != nil {
 			logging.Logger.Fatal().Err(err).Msg("auto migrate")
 		}
@@ -94,13 +96,14 @@ func main() {
 	case "sqlite", "postgres":
 		if dsn == "" {
 			srv = &routes.Server{
-				UserStore:       users.NewMemoryStore(),
-				KeyStore:        keys.NewMemoryStore(),
-				RootKeyStore:    rootkeys.NewMemoryStoreWithKey(encKey),
-				ServiceStore:    services.NewMemoryStore(),
-				OrgStore:        orgs.NewMemoryStore(),
-				MembershipStore: orgs.NewMemoryMembershipStore(),
-				UsageStore:      usage.NewMemoryStore(),
+				UserStore:           users.NewMemoryStore(),
+				KeyStore:            keys.NewMemoryStore(),
+				RootKeyStore:        rootkeys.NewMemoryStoreWithKey(encKey),
+				ServiceStore:        services.NewMemoryStore(),
+				OrgStore:            orgs.NewMemoryStore(),
+				MembershipStore:     orgs.NewMemoryMembershipStore(),
+				UsageStore:          usage.NewMemoryStore(),
+				ServiceAccountStore: serviceaccounts.NewMemoryStore(),
 			}
 			logging.Logger.Info().Msg("In-Memory Store set")
 		} else {
@@ -109,25 +112,27 @@ func main() {
 				logging.Logger.Fatal().Err(err).Msg("connect " + dbType)
 			}
 			srv = &routes.Server{
-				UserStore:       users.NewSQLStore(db),
-				KeyStore:        keys.NewSQLStore(db),
-				RootKeyStore:    rootkeys.NewSQLStoreWithKey(db, encKey),
-				ServiceStore:    services.NewSQLStore(db),
-				OrgStore:        orgs.NewSQLStore(db),
-				MembershipStore: orgs.NewSQLMembershipStore(db),
-				UsageStore:      usage.NewSQLStore(db),
+				UserStore:           users.NewSQLStore(db),
+				KeyStore:            keys.NewSQLStore(db),
+				RootKeyStore:        rootkeys.NewSQLStoreWithKey(db, encKey),
+				ServiceStore:        services.NewSQLStore(db),
+				OrgStore:            orgs.NewSQLStore(db),
+				MembershipStore:     orgs.NewSQLMembershipStore(db),
+				UsageStore:          usage.NewSQLStore(db),
+				ServiceAccountStore: serviceaccounts.NewSQLStore(db),
 			}
 			logging.Logger.Info().Str("db", dbType).Msg("Store set")
 		}
 	default:
 		srv = &routes.Server{
-			UserStore:       users.NewMemoryStore(),
-			KeyStore:        keys.NewMemoryStore(),
-			RootKeyStore:    rootkeys.NewMemoryStoreWithKey(encKey),
-			ServiceStore:    services.NewMemoryStore(),
-			OrgStore:        orgs.NewMemoryStore(),
-			MembershipStore: orgs.NewMemoryMembershipStore(),
-			UsageStore:      usage.NewMemoryStore(),
+			UserStore:           users.NewMemoryStore(),
+			KeyStore:            keys.NewMemoryStore(),
+			RootKeyStore:        rootkeys.NewMemoryStoreWithKey(encKey),
+			ServiceStore:        services.NewMemoryStore(),
+			OrgStore:            orgs.NewMemoryStore(),
+			MembershipStore:     orgs.NewMemoryMembershipStore(),
+			UsageStore:          usage.NewMemoryStore(),
+			ServiceAccountStore: serviceaccounts.NewMemoryStore(),
 		}
 		logging.Logger.Info().Msg("In-Memory Store set")
 	}
@@ -174,6 +179,9 @@ func main() {
 		r.With(rl.OrgCtxMiddleware(srv.MembershipStore)).Post("/user/rootkeys", srv.CreateRootKey)
 		r.Post("/token/refresh", srv.RefreshToken)
 
+		// Service-account token endpoint — authenticated by X-Service-Key, no user session required
+		r.Post("/service-token", srv.ServiceToken)
+
 		// Proxy - authenticated by the virtual key; no API key or token required
 		r.With(rl.RateLimitMiddleware(srv.KeyStore)).Handle("/proxy/*", http.HandlerFunc(v1h.Proxy))
 
@@ -198,6 +206,10 @@ func main() {
 			r.Post("/services", srv.CreateService)
 			r.Put("/services/{id}", srv.UpdateService)
 			r.Delete("/services/{id}", srv.DeleteService)
+
+			r.Get("/serviceaccounts", srv.ListServiceAccounts)
+			r.Post("/serviceaccounts", srv.CreateServiceAccount)
+			r.Delete("/serviceaccounts/{id}", srv.DeleteServiceAccount)
 
 			r.Get("/orgs", srv.ListOrgs)
 			r.Post("/orgs", srv.CreateOrg)

--- a/migrations/011_create_service_accounts.sql
+++ b/migrations/011_create_service_accounts.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS service_accounts (
+    id               VARCHAR(255) PRIMARY KEY,
+    name             VARCHAR(255) NOT NULL,
+    api_key          VARCHAR(255) NOT NULL UNIQUE,
+    allowed_services TEXT         NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_service_accounts_api_key ON service_accounts (api_key);

--- a/pkg/keys/virtualkey.go
+++ b/pkg/keys/virtualkey.go
@@ -18,4 +18,7 @@ type VirtualKey struct {
 // SourceMCP is the source label for keys issued via the MCP tool.
 const SourceMCP = "mcp"
 
+// SourceServiceAccount is the source label for keys issued via POST /v1/service-token.
+const SourceServiceAccount = "sa"
+
 func (VirtualKey) TableName() string { return "virtual_keys" }

--- a/pkg/serviceaccounts/serviceaccount.go
+++ b/pkg/serviceaccounts/serviceaccount.go
@@ -1,0 +1,57 @@
+package serviceaccounts
+
+import (
+	"database/sql/driver"
+	"errors"
+	"strings"
+)
+
+// ErrServiceAccountNotFound is returned when a service account lookup fails.
+var ErrServiceAccountNotFound = errors.New("service account not found")
+
+// ErrServiceAccountExists is returned when creating a duplicate service account.
+var ErrServiceAccountExists = errors.New("service account already exists")
+
+// StringList is a []string that serialises as a comma-separated value in SQL
+// and as a JSON array over the wire.
+//
+// TODO: revisit when org-scoping is added — AllowedServices may need to become
+// a join table keyed by (service_account_id, org_id, service_id).
+type StringList []string
+
+func (s StringList) Value() (driver.Value, error) {
+	return strings.Join(s, ","), nil
+}
+
+func (s *StringList) Scan(value interface{}) error {
+	if value == nil {
+		*s = StringList{}
+		return nil
+	}
+	str, ok := value.(string)
+	if !ok {
+		return errors.New("unsupported scan type for StringList")
+	}
+	if str == "" {
+		*s = StringList{}
+		return nil
+	}
+	*s = strings.Split(str, ",")
+	return nil
+}
+
+// ServiceAccount is a machine identity that can request virtual keys without
+// holding full management-level user privileges.
+//
+// NOTE (flat v1): service accounts are global to the Bifrost instance.
+// Org-scoped service accounts are deferred — see docs/backlog.md.
+// AllowedServices being empty means the account may request a key for any
+// registered service.
+type ServiceAccount struct {
+	ID              string     `json:"id" gorm:"primaryKey;size:255"`
+	Name            string     `json:"name" gorm:"not null;size:255"`
+	APIKey          string     `json:"api_key" gorm:"not null;uniqueIndex;size:255"`
+	AllowedServices StringList `json:"allowed_services" gorm:"type:text"`
+}
+
+func (ServiceAccount) TableName() string { return "service_accounts" }

--- a/pkg/serviceaccounts/store.go
+++ b/pkg/serviceaccounts/store.go
@@ -1,0 +1,162 @@
+package serviceaccounts
+
+import (
+	"sync"
+
+	"gorm.io/gorm"
+)
+
+// Store defines persistence behaviour for service accounts.
+type Store interface {
+	Create(ServiceAccount) error
+	Get(id string) (ServiceAccount, error)
+	GetByAPIKey(apiKey string) (ServiceAccount, error)
+	List() []ServiceAccount
+	Delete(id string) error
+}
+
+// MemoryStore is an in-memory Store used in tests and in-memory mode.
+type MemoryStore struct {
+	mu       sync.RWMutex
+	accounts []ServiceAccount
+}
+
+func NewMemoryStore() *MemoryStore { return &MemoryStore{} }
+
+func (s *MemoryStore) Create(sa ServiceAccount) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, a := range s.accounts {
+		if a.ID == sa.ID {
+			return ErrServiceAccountExists
+		}
+	}
+	s.accounts = append(s.accounts, sa)
+	return nil
+}
+
+func (s *MemoryStore) Get(id string) (ServiceAccount, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, a := range s.accounts {
+		if a.ID == id {
+			return a, nil
+		}
+	}
+	return ServiceAccount{}, ErrServiceAccountNotFound
+}
+
+func (s *MemoryStore) GetByAPIKey(apiKey string) (ServiceAccount, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, a := range s.accounts {
+		if a.APIKey == apiKey {
+			return a, nil
+		}
+	}
+	return ServiceAccount{}, ErrServiceAccountNotFound
+}
+
+func (s *MemoryStore) List() []ServiceAccount {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]ServiceAccount, len(s.accounts))
+	copy(out, s.accounts)
+	return out
+}
+
+func (s *MemoryStore) Delete(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, a := range s.accounts {
+		if a.ID == id {
+			s.accounts = append(s.accounts[:i], s.accounts[i+1:]...)
+			return nil
+		}
+	}
+	return ErrServiceAccountNotFound
+}
+
+// SQLStore persists service accounts in a SQL database via GORM.
+type SQLStore struct {
+	db *gorm.DB
+}
+
+func NewSQLStore(db *gorm.DB) *SQLStore {
+	db.AutoMigrate(&ServiceAccount{})
+	return &SQLStore{db: db}
+}
+
+func (s *SQLStore) Create(sa ServiceAccount) error {
+	result := s.db.Create(&sa)
+	if result.Error != nil {
+		if isUniqueViolation(result.Error) {
+			return ErrServiceAccountExists
+		}
+		return result.Error
+	}
+	return nil
+}
+
+func (s *SQLStore) Get(id string) (ServiceAccount, error) {
+	var sa ServiceAccount
+	if err := s.db.First(&sa, "id = ?", id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return ServiceAccount{}, ErrServiceAccountNotFound
+		}
+		return ServiceAccount{}, err
+	}
+	return sa, nil
+}
+
+func (s *SQLStore) GetByAPIKey(apiKey string) (ServiceAccount, error) {
+	var sa ServiceAccount
+	if err := s.db.First(&sa, "api_key = ?", apiKey).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return ServiceAccount{}, ErrServiceAccountNotFound
+		}
+		return ServiceAccount{}, err
+	}
+	return sa, nil
+}
+
+func (s *SQLStore) List() []ServiceAccount {
+	var accounts []ServiceAccount
+	s.db.Find(&accounts)
+	return accounts
+}
+
+func (s *SQLStore) Delete(id string) error {
+	result := s.db.Delete(&ServiceAccount{}, "id = ?", id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrServiceAccountNotFound
+	}
+	return nil
+}
+
+// isUniqueViolation reports whether err looks like a unique-constraint violation
+// across both SQLite and PostgreSQL.
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return contains(msg, "UNIQUE constraint failed") || // SQLite
+		contains(msg, "duplicate key value") // PostgreSQL
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/routes/server.go
+++ b/routes/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/farovictor/bifrost/pkg/keys"
 	"github.com/farovictor/bifrost/pkg/orgs"
 	"github.com/farovictor/bifrost/pkg/rootkeys"
+	"github.com/farovictor/bifrost/pkg/serviceaccounts"
 	"github.com/farovictor/bifrost/pkg/services"
 	"github.com/farovictor/bifrost/pkg/usage"
 	"github.com/farovictor/bifrost/pkg/users"
@@ -14,13 +15,14 @@ import (
 
 // Server holds all store dependencies for HTTP handlers.
 type Server struct {
-	UserStore       users.Store
-	KeyStore        keys.Store
-	RootKeyStore    rootkeys.Store
-	ServiceStore    services.Store
-	OrgStore        orgs.Store
-	MembershipStore orgs.MembershipStore
-	UsageStore      usage.Store
+	UserStore           users.Store
+	KeyStore            keys.Store
+	RootKeyStore        rootkeys.Store
+	ServiceStore        services.Store
+	OrgStore            orgs.Store
+	MembershipStore     orgs.MembershipStore
+	UsageStore          usage.Store
+	ServiceAccountStore serviceaccounts.Store
 }
 
 // ErrorResponse is the standard error body returned by all endpoints.

--- a/routes/serviceaccounts.go
+++ b/routes/serviceaccounts.go
@@ -1,0 +1,104 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/farovictor/bifrost/pkg/serviceaccounts"
+	"github.com/farovictor/bifrost/pkg/utils"
+)
+
+// CreateServiceAccount handles POST /v1/serviceaccounts.
+//
+// @Summary      Create service account
+// @Tags         service-accounts
+// @Accept       json
+// @Produce      json
+// @Param        body  body      serviceaccounts.ServiceAccount  true  "Service account to create"
+// @Success      201   {object}  serviceaccounts.ServiceAccount
+// @Failure      400   {object}  ErrorResponse
+// @Failure      409   {object}  ErrorResponse  "service account already exists"
+// @Failure      500   {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /v1/serviceaccounts [post]
+func (s *Server) CreateServiceAccount(w http.ResponseWriter, r *http.Request) {
+	var sa serviceaccounts.ServiceAccount
+	if err := json.NewDecoder(r.Body).Decode(&sa); err != nil {
+		writeError(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if sa.Name == "" {
+		writeError(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	if sa.ID == "" {
+		sa.ID = utils.GenerateID()
+	}
+	if sa.APIKey == "" {
+		sa.APIKey = "sa-" + utils.GenerateID()
+	}
+	if sa.AllowedServices == nil {
+		sa.AllowedServices = serviceaccounts.StringList{}
+	}
+
+	if err := s.ServiceAccountStore.Create(sa); err != nil {
+		switch err {
+		case serviceaccounts.ErrServiceAccountExists:
+			writeError(w, "service account already exists", http.StatusConflict)
+		default:
+			writeError(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(sa)
+}
+
+// ListServiceAccounts handles GET /v1/serviceaccounts.
+//
+// @Summary      List service accounts
+// @Tags         service-accounts
+// @Produce      json
+// @Success      200  {array}   serviceaccounts.ServiceAccount
+// @Failure      500  {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /v1/serviceaccounts [get]
+func (s *Server) ListServiceAccounts(w http.ResponseWriter, r *http.Request) {
+	list := s.ServiceAccountStore.List()
+	if list == nil {
+		list = []serviceaccounts.ServiceAccount{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(list)
+}
+
+// DeleteServiceAccount handles DELETE /v1/serviceaccounts/{id}.
+//
+// @Summary      Delete service account
+// @Tags         service-accounts
+// @Param        id   path      string  true  "Service account ID"
+// @Success      204
+// @Failure      404  {object}  ErrorResponse
+// @Failure      500  {object}  ErrorResponse
+// @Security     ApiKeyAuth
+// @Security     BearerAuth
+// @Router       /v1/serviceaccounts/{id} [delete]
+func (s *Server) DeleteServiceAccount(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if err := s.ServiceAccountStore.Delete(id); err != nil {
+		switch err {
+		case serviceaccounts.ErrServiceAccountNotFound:
+			writeError(w, "not found", http.StatusNotFound)
+		default:
+			writeError(w, "internal error", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/routes/servicetoken.go
+++ b/routes/servicetoken.go
@@ -1,0 +1,122 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/farovictor/bifrost/pkg/keys"
+	"github.com/farovictor/bifrost/pkg/serviceaccounts"
+	"github.com/farovictor/bifrost/pkg/services"
+)
+
+// servicetokenRequest is the body for POST /v1/service-token.
+type servicetokenRequest struct {
+	Service     string `json:"service"`
+	TTLSeconds  int    `json:"ttl_seconds"`
+	RateLimit   int    `json:"rate_limit"`
+}
+
+// servicetokenResponse is returned on a successful token request.
+type servicetokenResponse struct {
+	Key       string    `json:"key"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// ServiceToken handles POST /v1/service-token.
+// The caller authenticates via the X-Service-Key header using a service account API key.
+// It returns a short-lived virtual key scoped to the requested service.
+//
+// @Summary      Request a virtual key as a service account
+// @Tags         service-accounts
+// @Accept       json
+// @Produce      json
+// @Param        X-Service-Key  header    string                 true  "Service account API key"
+// @Param        body           body      servicetokenRequest    true  "Token request"
+// @Success      200            {object}  servicetokenResponse
+// @Failure      400            {object}  ErrorResponse
+// @Failure      401            {object}  ErrorResponse  "missing or invalid X-Service-Key"
+// @Failure      403            {object}  ErrorResponse  "service not in allowed list"
+// @Failure      404            {object}  ErrorResponse  "service not found"
+// @Failure      500            {object}  ErrorResponse
+// @Router       /v1/service-token [post]
+func (s *Server) ServiceToken(w http.ResponseWriter, r *http.Request) {
+	apiKey := r.Header.Get("X-Service-Key")
+	if apiKey == "" {
+		writeError(w, "missing X-Service-Key", http.StatusUnauthorized)
+		return
+	}
+
+	sa, err := s.ServiceAccountStore.GetByAPIKey(apiKey)
+	if err != nil {
+		if err == serviceaccounts.ErrServiceAccountNotFound {
+			writeError(w, "invalid service key", http.StatusUnauthorized)
+			return
+		}
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	var req servicetokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.Service == "" {
+		writeError(w, "service is required", http.StatusBadRequest)
+		return
+	}
+
+	// Enforce allowed_services when the list is non-empty.
+	if len(sa.AllowedServices) > 0 {
+		allowed := false
+		for _, svc := range sa.AllowedServices {
+			if svc == req.Service {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			writeError(w, "service not allowed for this service account", http.StatusForbidden)
+			return
+		}
+	}
+
+	// Verify the service exists.
+	if _, err := s.ServiceStore.Get(req.Service); err != nil {
+		if err == services.ErrServiceNotFound {
+			writeError(w, "service not found", http.StatusNotFound)
+			return
+		}
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	ttl := req.TTLSeconds
+	if ttl <= 0 {
+		ttl = 3600 // default 1 hour
+	}
+	rateLimit := req.RateLimit
+	if rateLimit <= 0 {
+		rateLimit = 60 // default 60 rpm
+	}
+
+	expiresAt := time.Now().Add(time.Duration(ttl) * time.Second)
+	k := keys.VirtualKey{
+		ID:        fmt.Sprintf("vk-sa-%d", time.Now().UnixNano()),
+		Target:    req.Service,
+		Scope:     keys.ScopeWrite,
+		RateLimit: rateLimit,
+		ExpiresAt: expiresAt,
+		Source:    keys.SourceServiceAccount,
+	}
+
+	if err := s.KeyStore.Create(k); err != nil {
+		writeError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(servicetokenResponse{Key: k.ID, ExpiresAt: expiresAt})
+}

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/farovictor/bifrost/pkg/keys"
 	"github.com/farovictor/bifrost/pkg/orgs"
 	"github.com/farovictor/bifrost/pkg/rootkeys"
+	"github.com/farovictor/bifrost/pkg/serviceaccounts"
 	"github.com/farovictor/bifrost/pkg/services"
 	"github.com/farovictor/bifrost/pkg/usage"
 	"github.com/farovictor/bifrost/pkg/users"
@@ -19,13 +20,14 @@ import (
 func newTestServer(t *testing.T) *routes.Server {
 	t.Helper()
 	return &routes.Server{
-		UserStore:       users.NewMemoryStore(),
-		KeyStore:        keys.NewMemoryStore(),
-		RootKeyStore:    rootkeys.NewMemoryStore(),
-		ServiceStore:    services.NewMemoryStore(),
-		OrgStore:        orgs.NewMemoryStore(),
-		MembershipStore: orgs.NewMemoryMembershipStore(),
-		UsageStore:      usage.NewMemoryStore(),
+		UserStore:           users.NewMemoryStore(),
+		KeyStore:            keys.NewMemoryStore(),
+		RootKeyStore:        rootkeys.NewMemoryStore(),
+		ServiceStore:        services.NewMemoryStore(),
+		OrgStore:            orgs.NewMemoryStore(),
+		MembershipStore:     orgs.NewMemoryMembershipStore(),
+		UsageStore:          usage.NewMemoryStore(),
+		ServiceAccountStore: serviceaccounts.NewMemoryStore(),
 	}
 }
 

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -29,6 +29,7 @@ func setupRouter(s *routes.Server) http.Handler {
 		r.With(rl.OrgCtxMiddleware(s.MembershipStore)).Get("/user", s.GetUserInfo)
 		r.With(rl.OrgCtxMiddleware(s.MembershipStore)).Post("/user/rootkeys", s.CreateRootKey)
 
+		r.Post("/service-token", s.ServiceToken)
 		r.With(rl.RateLimitMiddleware(s.KeyStore)).Handle("/proxy/*", http.HandlerFunc(v1h.Proxy))
 
 		r.Group(func(r chi.Router) {
@@ -46,6 +47,10 @@ func setupRouter(s *routes.Server) http.Handler {
 			r.Get("/services", s.ListServices)
 			r.Post("/services", s.CreateService)
 			r.Delete("/services/{id}", s.DeleteService)
+
+			r.Get("/serviceaccounts", s.ListServiceAccounts)
+			r.Post("/serviceaccounts", s.CreateServiceAccount)
+			r.Delete("/serviceaccounts/{id}", s.DeleteServiceAccount)
 
 			r.Get("/orgs", s.ListOrgs)
 			r.Post("/orgs", s.CreateOrg)

--- a/tests/serviceaccounts_test.go
+++ b/tests/serviceaccounts_test.go
@@ -1,0 +1,254 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/farovictor/bifrost/pkg/keys"
+	"github.com/farovictor/bifrost/pkg/rootkeys"
+	"github.com/farovictor/bifrost/pkg/serviceaccounts"
+	"github.com/farovictor/bifrost/pkg/services"
+)
+
+// ---- management endpoint tests ----
+
+func TestCreateServiceAccount_OK(t *testing.T) {
+	env := newTestEnv(t)
+	body := `{"name":"ci-pipeline"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/serviceaccounts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	env.Authorize(req)
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var sa serviceaccounts.ServiceAccount
+	if err := json.Unmarshal(rr.Body.Bytes(), &sa); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sa.ID == "" {
+		t.Error("expected generated ID")
+	}
+	if sa.APIKey == "" {
+		t.Error("expected generated api_key")
+	}
+	if sa.Name != "ci-pipeline" {
+		t.Errorf("unexpected name: %s", sa.Name)
+	}
+}
+
+func TestCreateServiceAccount_MissingName(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodPost, "/v1/serviceaccounts", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	env.Authorize(req)
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestCreateServiceAccount_Duplicate(t *testing.T) {
+	env := newTestEnv(t)
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{
+		ID: "sa-dup", Name: "dup", APIKey: "key-dup",
+	})
+	body := `{"id":"sa-dup","name":"dup2"}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/serviceaccounts", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	env.Authorize(req)
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", rr.Code)
+	}
+}
+
+func TestListServiceAccounts(t *testing.T) {
+	env := newTestEnv(t)
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{ID: "sa-1", Name: "one", APIKey: "k1"})
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{ID: "sa-2", Name: "two", APIKey: "k2"})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/serviceaccounts", nil)
+	env.Authorize(req)
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var list []serviceaccounts.ServiceAccount
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list) != 2 {
+		t.Errorf("expected 2 accounts, got %d", len(list))
+	}
+}
+
+func TestDeleteServiceAccount_OK(t *testing.T) {
+	env := newTestEnv(t)
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{ID: "sa-del", Name: "del", APIKey: "k-del"})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/serviceaccounts/sa-del", nil)
+	env.Authorize(req)
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", rr.Code)
+	}
+}
+
+func TestDeleteServiceAccount_NotFound(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodDelete, "/v1/serviceaccounts/no-such", nil)
+	env.Authorize(req)
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+// ---- POST /v1/service-token tests ----
+
+func seedServiceForToken(t *testing.T, env *TestEnv) string {
+	t.Helper()
+	rk := rootkeys.RootKey{ID: "rk-st", APIKey: "real"}
+	env.Server.RootKeyStore.Create(rk)
+	svc := services.Service{ID: "svc-st", Endpoint: "http://localhost", RootKeyID: rk.ID}
+	env.Server.ServiceStore.Create(svc)
+	return svc.ID
+}
+
+func TestServiceToken_OK(t *testing.T) {
+	env := newTestEnv(t)
+	svcID := seedServiceForToken(t, env)
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{
+		ID:     "sa-tok",
+		Name:   "ci",
+		APIKey: "sa-key-1",
+	})
+
+	body, _ := json.Marshal(map[string]interface{}{"service": svcID, "ttl_seconds": 60})
+	req := httptest.NewRequest(http.MethodPost, "/v1/service-token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Service-Key", "sa-key-1")
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Key       string    `json:"key"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Key == "" {
+		t.Error("expected a virtual key ID")
+	}
+	if resp.ExpiresAt.IsZero() {
+		t.Error("expected expires_at")
+	}
+
+	// Verify the virtual key was actually stored with the right source.
+	k, err := env.Server.KeyStore.Get(resp.Key)
+	if err != nil {
+		t.Fatalf("get key: %v", err)
+	}
+	if k.Source != keys.SourceServiceAccount {
+		t.Errorf("expected source=%q, got %q", keys.SourceServiceAccount, k.Source)
+	}
+}
+
+func TestServiceToken_MissingServiceKey(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodPost, "/v1/service-token", bytes.NewBufferString(`{"service":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestServiceToken_InvalidServiceKey(t *testing.T) {
+	env := newTestEnv(t)
+	req := httptest.NewRequest(http.MethodPost, "/v1/service-token", bytes.NewBufferString(`{"service":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Service-Key", "bad-key")
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestServiceToken_ServiceNotAllowed(t *testing.T) {
+	env := newTestEnv(t)
+	seedServiceForToken(t, env)
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{
+		ID:              "sa-restricted",
+		Name:            "restricted",
+		APIKey:          "sa-key-r",
+		AllowedServices: serviceaccounts.StringList{"other-svc"},
+	})
+
+	body, _ := json.Marshal(map[string]interface{}{"service": "svc-st"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/service-token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Service-Key", "sa-key-r")
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServiceToken_ServiceNotFound(t *testing.T) {
+	env := newTestEnv(t)
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{
+		ID: "sa-any", Name: "any", APIKey: "sa-key-any",
+	})
+
+	body, _ := json.Marshal(map[string]interface{}{"service": "no-such-svc"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/service-token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Service-Key", "sa-key-any")
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+func TestServiceToken_EmptyAllowedServicesAllowsAny(t *testing.T) {
+	env := newTestEnv(t)
+	svcID := seedServiceForToken(t, env)
+	env.Server.ServiceAccountStore.Create(serviceaccounts.ServiceAccount{
+		ID:              "sa-open",
+		Name:            "open",
+		APIKey:          "sa-key-open",
+		AllowedServices: serviceaccounts.StringList{}, // empty = allow all
+	})
+
+	body, _ := json.Marshal(map[string]interface{}{"service": svcID})
+	req := httptest.NewRequest(http.MethodPost, "/v1/service-token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Service-Key", "sa-key-open")
+	rr := httptest.NewRecorder()
+	env.Router.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (empty allowed_services = allow all), got %d: %s", rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- New `ServiceAccount` entity — separate from `User`, no management access
- `POST /v1/service-token` (auth via `X-Service-Key`) issues a short-lived virtual key without needing a user session
- Management CRUD behind normal user auth: `POST/GET /v1/serviceaccounts`, `DELETE /v1/serviceaccounts/{id}`
- `allowed_services` field: empty = allow any registered service, non-empty = restrict to listed service IDs
- Keys issued this way carry `source: "sa"` for traceability in usage logs
- Migration `011_create_service_accounts.sql`

## Design note
This is a flat v1 implementation — service accounts are global to the Bifrost instance. Org-scoped service accounts are documented as a future concern in `pkg/serviceaccounts/serviceaccount.go`.

## Usage (CI/CD pipeline example)
```bash
# Admin creates a service account once
curl -X POST /v1/serviceaccounts \
  -H "X-API-Key: ..." -H "Authorization: Bearer ..." \
  -d '{"name":"my-pipeline","allowed_services":["openai"]}'
# → {"id":"...","api_key":"sa-xxx","allowed_services":["openai"]}

# Pipeline requests a key at runtime (no user session needed)
curl -X POST /v1/service-token \
  -H "X-Service-Key: sa-xxx" \
  -d '{"service":"openai","ttl_seconds":300}'
# → {"key":"vk-sa-...","expires_at":"..."}
```

## Test plan
- [ ] `TestCreateServiceAccount_OK` — generates ID + api_key automatically
- [ ] `TestCreateServiceAccount_MissingName` — 400
- [ ] `TestCreateServiceAccount_Duplicate` — 409
- [ ] `TestListServiceAccounts` — returns all accounts
- [ ] `TestDeleteServiceAccount_OK` — 204
- [ ] `TestDeleteServiceAccount_NotFound` — 404
- [ ] `TestServiceToken_OK` — returns key with correct source
- [ ] `TestServiceToken_MissingServiceKey` — 401
- [ ] `TestServiceToken_InvalidServiceKey` — 401
- [ ] `TestServiceToken_ServiceNotAllowed` — 403
- [ ] `TestServiceToken_ServiceNotFound` — 404
- [ ] `TestServiceToken_EmptyAllowedServicesAllowsAny` — 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)